### PR TITLE
Always run apt-get update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build21) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- Oleksandr Kuzminskyi <aleks@infrahouse.com>  Sat, 19 Aug 2023 10:41:53 -0700
+
 puppet-code (0.1.0-1build20) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/repos.pp
+++ b/modules/profile/manifests/repos.pp
@@ -2,7 +2,7 @@
 class profile::repos () {
   class { 'apt':
     update => {
-      frequency => 'daily',
+      frequency => 'always',
     },
   }
 }


### PR DESCRIPTION
We want puppet to check for package updates every time it runs.
Otherwise any changes will be updated one day after.
