### PR TITLE
Run apt-get update before installing packages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build24) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- Oleksandr Kuzminskyi <aleks@infrahouse.com>  Mon, 21 Aug 2023 08:16:23 -0700
+
 puppet-code (0.1.0-1build23) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/base.pp
+++ b/modules/profile/manifests/base.pp
@@ -1,6 +1,8 @@
 # @summary: Base profile to be included by all roles.
 class profile::base () {
 
+  stage { 'init': before  => Stage['main'] }
+
   include 'profile::repos'
   include 'profile::packages'
   include 'profile::infrahouse_toolkit'

--- a/modules/profile/manifests/repos.pp
+++ b/modules/profile/manifests/repos.pp
@@ -1,6 +1,7 @@
 # @summary: Configures APT and repositories
 class profile::repos () {
   class { 'apt':
+    stage  => init,
     update => {
       frequency => 'always',
     },


### PR DESCRIPTION
Make sure that apt-get update runs before installing any new packages.
Otherwise, a new package version would be installed only after the
second puppet run.

This is done by using [run
stages](https://www.puppet.com/docs/puppet/8/lang_run_stages.html).
