### PR TITLE
GitHub Action role changed to ih-tf-puppet-code-github

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,7 +18,7 @@ permissions:
     contents: read
 
 env:
-    ROLE_ARN: "arn:aws:iam::493370826424:role/puppet-code-github"
+    ROLE_ARN: "arn:aws:iam::493370826424:role/ih-tf-puppet-code-github"
 
 jobs:
     deploy:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build27) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- Oleksandr Kuzminskyi <aleks@infrahouse.com>  Wed, 08 Nov 2023 05:23:51 -0800
+
 puppet-code (0.1.0-1build26) jammy; urgency=medium
 
   * commit event. see changes history in git log


### PR DESCRIPTION
The change is caused by https://github.com/infrahouse/aws-control-493370826424/pull/100
