### PR TITLE
Accept list of packages from `profile::packages`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+puppet-code (0.1.0-1build33) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
 puppet-code (0.1.0-1build32) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/packages.pp
+++ b/modules/profile/manifests/packages.pp
@@ -1,16 +1,21 @@
 # @summary: Installs foundation packages to be expected on all hosts.
-class profile::packages () {
+class profile::packages (
+  $packages = lookup(
+    'profile::packages', undef, undef, {
+      'awscli'             => present,
+      'jq'                 => present,
+      'make'               => present,
+      'net-tools'          => present,
+      'python3'            => present,
+      'python-is-python3'  => present,
+      'python3-virtualenv' => present,
+    }
+  )
+) {
 
-  package { [
-    'awscli',
-    'jq',
-    'make',
-    'net-tools',
-    'python3',
-    'python-is-python3',
-    'python3-virtualenv'
-  ]:
-    ensure => present
+  $packages.map |$item| {
+    package { $item[0]:
+      ensure => $item[1]
+    }
   }
-
 }


### PR DESCRIPTION
The manifest install the same packages by default:
```
{
      'awscli'             => present,
      'jq'                 => present,
      'make'               => present,
      'net-tools'          => present,
      'python3'            => present,
      'python-is-python3'  => present,
      'python3-virtualenv' => present,
    }
```

However it can accept the list from the `profile::packages` hiera.

Example:
```
profile::packages:
  mysql-client-core-8.0: latest
  bazel-bootstrap: present

```
