### PR TITLE
Add role ecsnode

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build39) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- Oleksandr Kuzminskyi <aleks@infrahouse.com>  Tue, 05 Dec 2023 17:12:30 -0800
+
 puppet-code (0.1.0-1build38) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/data/ecsnode.yaml
+++ b/environments/development/data/ecsnode.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - role::ecsnode

--- a/environments/production/data/ecsnode.yaml
+++ b/environments/production/data/ecsnode.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - role::ecsnode

--- a/environments/sandbox/data/ecsnode.yaml
+++ b/environments/sandbox/data/ecsnode.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - role::ecsnode

--- a/modules/profile/manifests/ecs.pp
+++ b/modules/profile/manifests/ecs.pp
@@ -1,0 +1,16 @@
+# @summary: Installs docker repo, package and starts the service.
+class profile::ecs () {
+  include 'profile::docker'
+
+  package { 'amazon-ecs-init':
+    ensure => latest
+  }
+
+  service { 'ecs':
+    ensure  => running,
+    require => [
+      Package['amazon-ecs-init'],
+      Service['docker'],
+    ]
+  }
+}

--- a/modules/role/manifests/ecsnode.pp
+++ b/modules/role/manifests/ecsnode.pp
@@ -1,0 +1,7 @@
+# @summary: Puppet role for a ECS node
+class role::ecsnode () {
+
+  include 'profile::base'
+  include 'profile::ecs'
+
+}

--- a/modules/role/manifests/jumphost.pp
+++ b/modules/role/manifests/jumphost.pp
@@ -2,5 +2,6 @@
 class role::jumphost () {
 
   include 'profile::base'
+  include 'profile::ecs'
 
 }


### PR DESCRIPTION
The ecsnode role is an EC2 instance connected to the ECS service.
