### PR TITLE
Rename make test to make test-puppet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ bumpversion:
 		debhelper; \
 		DEBEMAIL=packager@infrahouse.com dch --distribution jammy -R 'commit event. see changes history in git log'"
 
-.PHONY: test
-test:
+.PHONY: test-puppet
+test-puppet:
 	sudo ih-puppet \
      --environment development \
      --environmentpath {root_directory}/environments \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build48) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 07 Feb 2024 17:30:37 +0000
+
 puppet-code (0.1.0-1build47) jammy; urgency=medium
 
   * commit event. see changes history in git log


### PR DESCRIPTION
debian build scripts run `make test` if it's available. It fails because `make test` was intended to be a command to test puppet manifests on a remote server.
Renaming the Makefile target, so the build script doesn't fail.
