### PR TITLE
Read cluster name from facts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build55) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Fri, 09 Feb 2024 00:39:37 +0000
+
 puppet-code (0.1.0-1build54) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/elastic/config.pp
+++ b/modules/profile/manifests/elastic/config.pp
@@ -1,11 +1,9 @@
 # @summary: Installs elasicsearch service.
 class profile::elastic::config (
   String $role = 'master',
-  String $cluster_name = 'elasticsearch',
 ) {
 
   $elastic_cluster_role = $role
-  $elastic_cluster_name = $cluster_name
   file { '/etc/elasticsearch/elasticsearch.yml':
     ensure  => file,
     content => template('profile/elasticsearch.yml.erb'),

--- a/modules/profile/manifests/elastic_data.pp
+++ b/modules/profile/manifests/elastic_data.pp
@@ -7,6 +7,5 @@ class profile::elastic_data () {
 
   class { 'profile::elastic::config':
     role         => 'data',
-    cluster_name => lookup('elasticsearch::cluster::name', undef, undef, 'elasticsearch'),
   }
 }

--- a/modules/profile/manifests/elastic_master.pp
+++ b/modules/profile/manifests/elastic_master.pp
@@ -7,6 +7,5 @@ class profile::elastic_master () {
 
   class { 'profile::elastic::config':
     role         => 'master',
-    cluster_name => lookup('elasticsearch::cluster::name', undef, undef, 'elasticsearch'),
   }
 }

--- a/modules/profile/templates/elasticsearch.yml.erb
+++ b/modules/profile/templates/elasticsearch.yml.erb
@@ -5,7 +5,7 @@ network.host: _ec2_
 
 node.roles: [<%= @elastic_cluster_role %>]
 
-cluster.name: <%= @elastic_cluster_name %>
+cluster.name: <%= @facts['elasticsearch']['cluster_name'] %>
 <% if @facts['elasticsearch']['bootstrap_cluster'] -%>
 cluster.initial_master_nodes: <%= @facts['ec2_metadata']['local-ipv4'] %>
 <% end -%>


### PR DESCRIPTION
The manifest already does it.
```
discovery.ec2.tag.cluster: <%= @facts['elasticsearch']['cluster_name'] %>
```

Adding `$cluster_name` to the config class was a mistake, it led to
potential inconsistencies.
Remove the class argument and use the fact for the cluster name.
