### PR TITLE
Configure TLS on Elasticsearch transport

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build56) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sun, 11 Feb 2024 03:33:42 +0000
+
 puppet-code (0.1.0-1build55) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/elastic/config.pp
+++ b/modules/profile/manifests/elastic/config.pp
@@ -4,9 +4,59 @@ class profile::elastic::config (
 ) {
 
   $elastic_cluster_role = $role
+
+  $hostname = $facts['networking']['hostname']
+  $le_domain = $facts['letsencrypt']['domain']
+  $le_fqdn = "${hostname}.${le_domain}"
+
+  file { '/etc/elasticsearch/letsencrypt':
+    ensure => directory,
+    owner  => 'elasticsearch',
+    mode   => '0700',
+  }
+
+  file { '/etc/elasticsearch/letsencrypt/privkey.pem':
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    source  => "/etc/letsencrypt/live/${le_fqdn}/privkey.pem",
+    links   => follow,
+    require => [
+      Exec['obtain_certificate'],
+      File['/etc/elasticsearch/letsencrypt'],
+    ]
+  }
+
+  file { '/etc/elasticsearch/letsencrypt/cert.pem':
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    source  => "/etc/letsencrypt/live/${le_fqdn}/cert.pem",
+    links   => follow,
+    require => [
+      Exec['obtain_certificate'],
+      File['/etc/elasticsearch/letsencrypt'],
+    ]
+  }
+
+  file { '/etc/elasticsearch/letsencrypt/fullchain.pem':
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    source  => "/etc/letsencrypt/live/${le_fqdn}/fullchain.pem",
+    links   => follow,
+    require => [
+      Exec['obtain_certificate'],
+      File['/etc/elasticsearch/letsencrypt'],
+    ]
+  }
+
   file { '/etc/elasticsearch/elasticsearch.yml':
     ensure  => file,
     content => template('profile/elasticsearch.yml.erb'),
     notify  => Service['elasticsearch'],
+    require => [
+      Exec['obtain_certificate']
+    ],
   }
 }

--- a/modules/profile/manifests/elastic/service.pp
+++ b/modules/profile/manifests/elastic/service.pp
@@ -1,6 +1,8 @@
 # @summary: Installs elasicsearch service.
 class profile::elastic::service () {
 
+  include 'profile::letsencrypt'
+
   exec { 'reload-systemd-for-elastic':
     path        => '/bin',
     command     => 'systemctl daemon-reload',

--- a/modules/profile/manifests/letsencrypt.pp
+++ b/modules/profile/manifests/letsencrypt.pp
@@ -1,4 +1,22 @@
 # @summary: Obtains an SSL certificate from https://letsencrypt.org/
 class profile::letsencrypt () {
   require 'profile::infrahouse_toolkit'
+
+  $hostname = $facts['networking']['hostname']
+  $le_domain = $facts['letsencrypt']['domain']
+  $le_email = $facts['letsencrypt']['email']
+  $le_fqdn = "${hostname}.${le_domain}"
+
+  exec { 'obtain_certificate':
+    path    => '/usr/local/bin',
+    command => "ih-certbot certonly -d ${le_fqdn} --dns-route53 --agree-tos --email ${le_email}",
+    creates => "/etc/letsencrypt/live/${le_fqdn}/privkey.pem",
+  }
+
+  cron { 'certbot_renew':
+    command => '/usr/local/bin/ih-certbot --quiet renew',
+    minute  =>  fqdn_rand(60),
+    hour    =>  fqdn_rand(24),
+    weekday => fqdn_rand(7),
+  }
 }

--- a/modules/profile/manifests/letsencrypt.pp
+++ b/modules/profile/manifests/letsencrypt.pp
@@ -1,0 +1,4 @@
+# @summary: Obtains an SSL certificate from https://letsencrypt.org/
+class profile::letsencrypt () {
+  require 'profile::infrahouse_toolkit'
+}

--- a/modules/profile/templates/elasticsearch.yml.erb
+++ b/modules/profile/templates/elasticsearch.yml.erb
@@ -15,10 +15,14 @@ discovery.ec2.tag.cluster: <%= @facts['elasticsearch']['cluster_name'] %>
 discovery.ec2.tag.environment: <%= @facts['puppet_environment'] %>
 
 xpack.security.audit.enabled: true
-xpack.security.enabled: false
+xpack.security.enabled: true
 xpack.security.autoconfiguration.enabled: false
 xpack.security.enrollment.enabled: false
 xpack.security.http.ssl.enabled: false
-xpack.security.transport.ssl.enabled: false
+
+xpack.security.transport.ssl.enabled: true
+xpack.security.transport.ssl.key: "/etc/elasticsearch/letsencrypt/privkey.pem"
+xpack.security.transport.ssl.certificate: "/etc/elasticsearch/letsencrypt/cert.pem"
+xpack.security.transport.ssl.certificate_authorities: "/etc/elasticsearch/letsencrypt/fullchain.pem"
 
 logger.org.elasticsearch.discovery.ec2: "INFO"


### PR DESCRIPTION
- Obtain SSL certificates form Elasticsearch
- Configure TLS on the elasticsearch transport
