### PR TITLE
[ES]: Set verification_mode to certificate

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build60) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 13 Feb 2024 21:50:09 +0000
+
 puppet-code (0.1.0-1build59) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/templates/elasticsearch.yml.erb
+++ b/modules/profile/templates/elasticsearch.yml.erb
@@ -24,6 +24,7 @@ xpack.security.http.ssl.enabled: false
 xpack.security.transport.ssl.enabled: true
 xpack.security.transport.ssl.key: "/etc/elasticsearch/letsencrypt/privkey.pem"
 xpack.security.transport.ssl.certificate: "/etc/elasticsearch/letsencrypt/fullchain.pem"
+xpack.security.transport.ssl.verification_mode: certificate
 
 xpack.security.authc:
   anonymous:


### PR DESCRIPTION
As per https://discuss.elastic.co/t/receiving-no-subject-alternative-names-matching-ip-address-when-using-wildcard-cert-in-es-5-0-2-cluster/69322/8

> One workaround that decreases the security a bit is turning off hostname verification; only the certificate that is presented will be verified and the host information will not be checked. You are already using a wild card certificate so hostname verification is already less secure as you are only verifying the domain of the server (*.foo.com). If you choose to turn off hostname verification, the setting would be xpack.security.transport.ssl.verification_mode: certificate.
