### PR TITLE
[ES]: master needs to be remote_cluster_client

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build61) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 14 Feb 2024 23:44:24 +0000
+
 puppet-code (0.1.0-1build60) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/elastic_master.pp
+++ b/modules/profile/manifests/elastic_master.pp
@@ -6,6 +6,6 @@ class profile::elastic_master () {
   include 'profile::elastic::service'
 
   class { 'profile::elastic::config':
-    role         => 'master',
+    role         => 'master, remote_cluster_client',
   }
 }


### PR DESCRIPTION
For kibana remote access the elasticsearch master needs to have role remote_cluster_client.
See https://discuss.elastic.co/t/this-node-does-not-have-the-remote-cluster-client-role/266294 for details.
