### PR TITLE
Add role terraformer

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build70) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 19 Mar 2024 20:50:11 +0000
+
 puppet-code (0.1.0-1build69) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/data/terraformer.yaml
+++ b/environments/development/data/terraformer.yaml
@@ -1,0 +1,5 @@
+---
+classes:
+  - role::terraformer
+
+profile::terraformer::terraform_version: "1.6.6-1"

--- a/environments/production/data/jumphost.yaml
+++ b/environments/production/data/jumphost.yaml
@@ -1,3 +1,5 @@
 ---
 classes:
   - role::jumphost
+
+profile::terraformer::terraform_version: "latest"

--- a/environments/production/data/terraformer.yaml
+++ b/environments/production/data/terraformer.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - role::terraformer

--- a/environments/sandbox/data/terraformer.yaml
+++ b/environments/sandbox/data/terraformer.yaml
@@ -1,0 +1,5 @@
+---
+classes:
+  - role::terraformer
+
+profile::terraformer::terraform_version: "1.6.6-1"

--- a/modules/profile/manifests/terraformer.pp
+++ b/modules/profile/manifests/terraformer.pp
@@ -1,0 +1,10 @@
+# @summary: Terraformer profile.
+class profile::terraformer (
+  $terraform_version = lookup(
+    'profile::terraformer::terraform_version', undef, undef, 'latest'
+  )
+) {
+  package { 'terraform':
+    ensure => $terraform_version
+  }
+}

--- a/modules/role/manifests/terraformer.pp
+++ b/modules/role/manifests/terraformer.pp
@@ -1,0 +1,7 @@
+# @summary: Puppet role for a terraformer instance
+class role::terraformer () {
+
+  include 'profile::base'
+  include 'profile::terraformer'
+
+}


### PR DESCRIPTION
The terraformer role configures Terraform environment. It is meant to be
used for Terraform maintenance operations - state fixes, migration, etc.
