### PR TITLE
Pass manifest to cron job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,6 @@ test-puppet:
 	sudo ih-puppet \
      --environment development \
      --environmentpath {root_directory}/environments \
-     --root-directory /home/ubuntu/code/puppet-code \
+     --root-directory /home/aleks/code/puppet-code \
      --hiera-config {root_directory}/environments/{environment}/hiera.yaml \
      --module-path {root_directory}/modules apply

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build71) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Fri, 22 Mar 2024 02:21:10 +0000
+
 puppet-code (0.1.0-1build70) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/packages.pp
+++ b/modules/profile/manifests/packages.pp
@@ -9,6 +9,7 @@ class profile::packages (
       'python3'            => present,
       'python-is-python3'  => present,
       'python3-virtualenv' => present,
+      'sysstat'            => present,
     }
   )
 ) {

--- a/modules/profile/manifests/puppet_apply.pp
+++ b/modules/profile/manifests/puppet_apply.pp
@@ -22,6 +22,7 @@ class profile::puppet_apply () {
     '--module-path',
     $facts['ih-puppet']['module-path'],
     'apply',
+    $facts['ih-puppet'].get('manifest', '')
   ]
 
   $m = fqdn_rand(30)


### PR DESCRIPTION
If the manifest file is specified in puppet facts, use it for the cron
job.
