### PR TITLE
Accept local mail for fqdn

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+puppet-code (0.1.0-1build76) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 27 Mar 2024 15:32:52 +0000
+
+puppet-code (0.1.0-1build75) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 27 Mar 2024 15:32:33 +0000
+
 puppet-code (0.1.0-1build74) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/postfix/config.pp
+++ b/modules/profile/manifests/postfix/config.pp
@@ -16,7 +16,7 @@ class profile::postfix::config (
     'profile::postfix::mynetworks', undef, undef, []
   ),
 ) {
-  $postfix_mydestination = ($mydestination + [$myhostname, $mydomain, 'localhost']).join(',')
+  $postfix_mydestination = ($mydestination + [$myhostname, $mydomain, $facts['networking']['fqdn'], 'localhost']).join(',')
   $postfix_relayhost = $relayhost.join(',')
   $postfix_mynetworks = ($mynetworks + ['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']).join(',')
 


### PR DESCRIPTION
Local clients may send emails to addresses like
root@ip-10-0-3-30.us-west-1.compute.internal
