### PR TITLE
Labal actions runner with instance-id

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build79) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Thu, 11 Apr 2024 20:29:53 +0000
+
 puppet-code (0.1.0-1build78) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/github_runner/register.pp
+++ b/modules/profile/manifests/github_runner/register.pp
@@ -9,7 +9,8 @@ class profile::github_runner::register (
 ) {
 
   $hostname = $facts['networking']['hostname']
-  $labels = $runner_labels.map |$label| {
+  $instance_id = $facts['ec2_metadata']['instance-id']
+  $labels = ($runner_labels + ["instance_id:${instance_id}"]).map |$label| {
     "--label ${label}"
   }
   $labels_arg = join($labels, ' ')


### PR DESCRIPTION
hostname isn't reliable, sometimes it's missing in the instance metadata
