### PR TITLE
elastic_data role accepts `profile::elastic::config::role`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+puppet-code (0.1.0-1build89) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 21 May 2024 04:19:04 +0000
+
+puppet-code (0.1.0-1build88) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 21 May 2024 04:09:33 +0000
+
 puppet-code (0.1.0-1build87) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/data/elastic_data.yaml
+++ b/environments/development/data/elastic_data.yaml
@@ -5,3 +5,5 @@ classes:
 accounts::user_list:
   ubuntu:
     group: 'admin'
+
+profile::elastic::config::role: 'data, transform'

--- a/modules/profile/manifests/elastic_data.pp
+++ b/modules/profile/manifests/elastic_data.pp
@@ -8,6 +8,11 @@ class profile::elastic_data () {
   include 'profile::elastic::backups'
 
   class { 'profile::elastic::config':
-    role         => 'data',
+    role => lookup(
+      'profile::elastic::config::role',
+      undef,
+      undef,
+      'data'
+    ),
   }
 }


### PR DESCRIPTION
By default, elsatic_data role provisions a node with `data` role.
However, one might need to assign additional roles.

A comma-separated list of roles can be specified in a hiera key
`profile::elastic::config::role`

For example,

`environments/development/data/elastic_data.yaml`
```
profile::elastic::config::role: 'data, transform'
```
