### PR TITLE
Retry apt-get update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build108) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 25 Jun 2024 17:58:14 +0000
+
 puppet-code (0.1.0-1build107) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/repos.pp
+++ b/modules/profile/manifests/repos.pp
@@ -4,6 +4,7 @@ class profile::repos () {
     stage  => init,
     update => {
       frequency => 'always',
+      tries     => 5,
     },
   }
 }


### PR DESCRIPTION
It takes some time ClodFront to update checksum files. When the update
is in progress, apt-get update fails. Try 5 times to workaround.
