### PR TITLE
Allow to specify elasticsearch_version via hiera

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build129) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Thu, 12 Sep 2024 21:44:40 +0000
+
 puppet-code (0.1.0-1build128) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/elastic/packages.pp
+++ b/modules/profile/manifests/elastic/packages.pp
@@ -1,8 +1,15 @@
 # @summary: Installs elasicsearch packages.
-class profile::elastic::packages () {
+class profile::elastic::packages (
+  String $elasticsearch_version = lookup(
+    'profile::elastic::packages::elasticsearch_version',
+    undef,
+    undef,
+    'present'
+  ),
+) {
 
   package { 'elasticsearch':
-    ensure  => present,
+    ensure  => $elasticsearch_version,
     require => [
       File['/etc/apt/sources.list.d/elastic-8.x.list'],
       Exec['update-elastic-repo'],


### PR DESCRIPTION
The hiera key is `profile::elastic::packages::elasticsearch_version`.
Default value is `present`.
