### PR TITLE
Require prometheus-elasticsearch-exporter for service file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build146) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Fri, 25 Oct 2024 00:59:30 +0000
+
 puppet-code (0.1.0-1build145) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/sandbox/modules/profile/manifests/elastic/prometheus.pp
+++ b/environments/sandbox/modules/profile/manifests/elastic/prometheus.pp
@@ -26,9 +26,10 @@ class profile::elastic::prometheus (
   }
 
   file { '/lib/systemd/system/prometheus-elasticsearch-exporter.service':
-    ensure => file,
-    source => 'puppet:///modules/profile/elastic_master/prometheus-elasticsearch-exporter.service',
-    notify => Exec['reload-systemd-prometheus-elasticsearch-exporter']
+    ensure  => file,
+    source  => 'puppet:///modules/profile/elastic_master/prometheus-elasticsearch-exporter.service',
+    notify  => Exec['reload-systemd-prometheus-elasticsearch-exporter'],
+    require => Package['prometheus-elasticsearch-exporter'],
   }
 
   exec { 'reload-systemd-prometheus-elasticsearch-exporter':


### PR DESCRIPTION
Why - `/lib/systemd/system/prometheus-elasticsearch-exporter.service` ships with the `prometheus-elasticsearch-exporter` package.
If the file is landed before the package is installed, then the package overwrites the file.
