### PR TITLE
Remove $mydomain from postfix destinations.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build155) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Thu, 14 Nov 2024 23:56:55 +0000
+
 puppet-code (0.1.0-1build154) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/postfix/config.pp
+++ b/modules/profile/manifests/postfix/config.pp
@@ -21,7 +21,7 @@ class profile::postfix::config (
     'profile::postfix::whitelist_domains', undef, undef, []
   ),
 ) {
-  $postfix_mydestination = ($mydestination + [$myhostname, $mydomain, $facts['networking']['fqdn'], 'localhost']).join(',')
+  $postfix_mydestination = ($mydestination + [$myhostname, $facts['networking']['fqdn'], 'localhost']).join(',')
   $postfix_relayhost = $relayhost
   $postfix_mynetworks = ($mynetworks + ['127.0.0.0/8', '[::ffff:127.0.0.0]/104', '[::1]/128']).join(',')
   $postfix_whitelist_domains = ($whitelist_domains + ['google.com'])


### PR DESCRIPTION
Why?
When a host is in a domain foo.com, it doesn't mean it receives mail for
foo.com. Unless it's an MX of it.

When the host is an MX for $mydomain, the domain should be added to
`profile::postfix::mydestination`.
