### PR TITLE
Use relative path to gem

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build161) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sat, 21 Dec 2024 16:21:50 +0000
+
 puppet-code (0.1.0-1build160) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/base.pp
+++ b/modules/profile/manifests/base.pp
@@ -16,11 +16,11 @@ class profile::base () {
     'json', 'aws-sdk-core', 'aws-sdk-secretsmanager'
   ]
 
-  $gem_cmd = '/opt/puppetlabs/puppet/bin/gem'
+  $gem_cmd = 'gem'
   $gems.each |$gem| {
     exec { "gem_install_${gem}":
       command => "${gem_cmd} install ${gem}",
-      path    => '/bin:/usr/bin',
+      path    => '/bin:/usr/bin:/opt/puppetlabs/puppet/bin',
       unless  => "${gem_cmd} list | grep ${gem}",
     }
   }


### PR DESCRIPTION
On focal, jammy, noble, gem is installed in /opt/puppetlabs/puppet/bin.
On oracular, however, it's in /usr/bin.
