### PR TITLE
Use `$facts['ec2_metadata']['hostname']` on oracular

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build165) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sat, 21 Dec 2024 17:37:58 +0000
+
 puppet-code (0.1.0-1build164) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/postfix/config.pp
+++ b/environments/development/modules/profile/manifests/postfix/config.pp
@@ -49,9 +49,15 @@ class profile::postfix::config (
     false => 'no'
   }
 
+  if $mydomain == '.' {
+    $fqdn = $facts['ec2_metadata']['hostname']
+  } else {
+    $fqdn = "${myhostname}.${mydomain}"
+  }
+
   file { '/etc/mailname':
     ensure  => file,
-    content => "${myhostname}.${mydomain}",
+    content => $fqdn,
     owner   => 'root',
     mode    => '0644',
     notify  => Service['postfix'],
@@ -70,7 +76,7 @@ class profile::postfix::config (
 
   file { '/etc/hostname':
     ensure  => file,
-    content => "${myhostname}.${mydomain}\n",
+    content => "${fqdn}\n",
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
@@ -81,13 +87,13 @@ class profile::postfix::config (
     ensure       => present,
     ip           => $facts['networking']['ip'],
     host_aliases => [
-      "${myhostname}.${mydomain}"
+      $fqdn
     ],
     target       => '/etc/hosts',
   }
 
   file { '/etc/postfix/generic':
-    content => "root root@${myhostname}.${mydomain}\n",
+    content => "root root@${fqdn}\n",
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
@@ -96,7 +102,7 @@ class profile::postfix::config (
   }
 
   exec { 'refesh_hostname':
-    command     => "/usr/bin/hostname ${myhostname}.${mydomain}",
+    command     => "/usr/bin/hostname ${fqdn}",
     refreshonly => true,
   }
 

--- a/environments/sandbox/modules/profile/templates/postfix/reject_senders.erb
+++ b/environments/sandbox/modules/profile/templates/postfix/reject_senders.erb
@@ -1,0 +1,3 @@
+<% @postfix_blacklist_senders.each do |sender| %>
+<%= sender %>  REJECT
+<% end %>

--- a/environments/sandbox/modules/profile/templates/puppet-lookup.erb
+++ b/environments/sandbox/modules/profile/templates/puppet-lookup.erb
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "Usage:"
+  echo ""
+  echo "$0 hiera_key"
+  echo ""
+  echo "For example, $0 classes"
+}
+
+trap usage ERR
+
+<%= @puppet_lookup %> $1


### PR DESCRIPTION
On oracular, `$facts['networking']['domain']` is equal to `.`. Not sure
if it's a bug or intended AMI property, but it breaks postfix in the
current state.
So, when the domain is ".", use ec2_metadata->hostname as a FQDN.

P.S.
    Forgot to include sandbox files.
