### PR TITLE
Remove elastic repo

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build168) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Mon, 03 Feb 2025 18:01:45 +0000
+
 puppet-code (0.1.0-1build167) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/elastic_data.pp
+++ b/modules/profile/manifests/elastic_data.pp
@@ -1,7 +1,6 @@
 # @summary: Elasticsearch data node.
 class profile::elastic_data () {
 
-  include 'profile::elastic::repo'
   include 'profile::elastic::packages'
   include 'profile::elastic::service'
   include 'profile::elastic::kibana_user'

--- a/modules/profile/manifests/elastic_master.pp
+++ b/modules/profile/manifests/elastic_master.pp
@@ -1,7 +1,6 @@
 # @summary: Elasticsearch master node.
 class profile::elastic_master () {
 
-  include 'profile::elastic::repo'
   include 'profile::elastic::packages'
   include 'profile::elastic::service'
   include 'profile::elastic::prometheus'


### PR DESCRIPTION
The elastic repo is broken after it moved to Artifactory
```
E: Repository 'https://artifacts.elastic.co/packages/8.x/apt stable InRelease' changed its 'Origin' value from 'elastic' to 'Artifactory'
E: Repository 'https://artifacts.elastic.co/packages/8.x/apt stable InRelease' changed its 'Label' value from '. stable' to 'Artifactory'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```
Instead, pull elasticsearch packages from InfraHouse repo.
