### PR TITLE
Create a self-signed CA certificate for elastic in development

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build171) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sat, 15 Feb 2025 19:59:16 +0000
+
 puppet-code (0.1.0-1build170) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/elastic/config.pp
+++ b/environments/development/modules/profile/manifests/elastic/config.pp
@@ -52,6 +52,18 @@ class profile::elastic::config (
     ]
   }
 
+  file { '/etc/elasticsearch/letsencrypt/chain.pem':
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    source  => "/etc/letsencrypt/live/${le_fqdn}/chain.pem",
+    links   => follow,
+    require => [
+      Exec['obtain_certificate'],
+      File['/etc/elasticsearch/letsencrypt'],
+    ]
+  }
+
   file { '/etc/elasticsearch/elasticsearch.yml':
     ensure  => file,
     content => template('profile/elasticsearch.yml.erb'),

--- a/environments/development/modules/profile/manifests/elastic/packages.pp
+++ b/environments/development/modules/profile/manifests/elastic/packages.pp
@@ -11,6 +11,9 @@ class profile::elastic::packages (
   package { 'elasticsearch':
     ensure => $elasticsearch_version,
   }
+  package { 'openssl':
+    ensure => present,
+  }
 
   exec { 'install-discovery-ec2':
     command => '/usr/share/elasticsearch/bin/elasticsearch-plugin install --batch discovery-ec2',

--- a/environments/development/modules/profile/manifests/elastic/tls.pp
+++ b/environments/development/modules/profile/manifests/elastic/tls.pp
@@ -1,0 +1,121 @@
+# @summary: Installs TLS certificates.
+class profile::elastic::tls (
+) {
+
+  $hostname = $facts['networking']['hostname']
+  $le_domain = $facts['letsencrypt']['domain']
+  $le_fqdn = "${hostname}.${le_domain}"
+
+  $tsl_dir = '/etc/elasticsearch/tls'
+  file { $tsl_dir:
+    ensure => directory,
+    owner  => 'elasticsearch',
+    mode   => '0700',
+  }
+
+  # CA key
+  $ca_key = "${tsl_dir}/ca.key"
+  file { $ca_key:
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    content => aws_get_secret(
+      $facts['elasticsearch']['ca_key_secret'], $facts['ec2_metadata']['placement']['region']
+    )
+  }
+  # CA certificate
+  $ca_cert = "${tsl_dir}/ca.cert"
+  file { $ca_cert:
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    content => aws_get_secret(
+      $facts['elasticsearch']['ca_cert_secret'], $facts['ec2_metadata']['placement']['region']
+    )
+  }
+
+  # Node private key
+  $node_key = "${tsl_dir}/${le_fqdn}.pem"
+  exec { 'generate_node_key':
+    command => "openssl genrsa -out ${node_key} 4096",
+    creates => $node_key,
+    path    => ['/usr/bin', '/usr/local/bin'],
+    require => Package['openssl'],
+  }
+  file { $node_key:
+    ensure  => present,
+      owner => 'elasticsearch',
+      mode  => '0600',
+    require => Exec[generate_node_key],
+  }
+
+  # Certificate request
+  $node_cert_request = "${tsl_dir}/${le_fqdn}.csr"
+  exec { 'generate_node_csr':
+    command => "openssl req -new -key ${node_key} -out ${node_cert_request} -subj '/C=US/ST=CA/L=San Francisco/O=InfraHouse/CN=${le_fqdn}'",
+    creates => $node_cert_request,
+    path    => ['/usr/bin', '/usr/local/bin'],
+    require => [
+      File[$node_key],
+    ]
+  }
+  file { $node_cert_request:
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    require => Exec[generate_node_csr],
+  }
+
+  # Sign node certificate
+  $node_cert = "${tsl_dir}/${le_fqdn}.cert"
+  exec { 'generate_node_pem':
+    command => @("EOF"),
+    openssl x509 \
+      -req -in ${node_cert_request} \
+      -CA ${ca_cert} \
+      -CAkey ${ca_key} \
+      -CAcreateserial \
+      -out ${node_cert} \
+      -days 3650 \
+      -sha256
+    | EOF
+    creates => $node_cert,
+    path    => ['/usr/bin', '/usr/local/bin'],
+    require => [
+      File[$node_cert_request],
+      File[$ca_cert],
+      File[$ca_key],
+    ]
+  }
+  file { $node_cert:
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    require => Exec[generate_node_pem],
+  }
+# Let's encrypt root certificates
+  package {'ca-certificates':
+    ensure => present,
+  }
+  file { '/etc/elasticsearch/tls/ISRG_Root_X1.crt':
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    source  => '/usr/share/ca-certificates/mozilla/ISRG_Root_X1.crt',
+    links   => follow,
+    require => [
+      Package['ca-certificates']
+    ]
+  }
+
+  file { '/etc/elasticsearch/tls/ISRG_Root_X2.crt':
+    ensure  => present,
+    owner   => 'elasticsearch',
+    mode    => '0600',
+    source  => '/usr/share/ca-certificates/mozilla/ISRG_Root_X2.crt',
+    links   => follow,
+    require => [
+      Package['ca-certificates']
+    ]
+  }
+}

--- a/environments/development/modules/profile/manifests/elastic_data.pp
+++ b/environments/development/modules/profile/manifests/elastic_data.pp
@@ -6,6 +6,7 @@ class profile::elastic_data () {
   include 'profile::elastic::kibana_user'
   include 'profile::elastic::backups'
   include 'profile::elastic::prometheus'
+  include 'profile::elastic::tls'
 
   class { 'profile::elastic::config':
     role => lookup(

--- a/environments/development/modules/profile/manifests/elastic_master.pp
+++ b/environments/development/modules/profile/manifests/elastic_master.pp
@@ -4,6 +4,7 @@ class profile::elastic_master () {
   include 'profile::elastic::packages'
   include 'profile::elastic::service'
   include 'profile::elastic::prometheus'
+  include 'profile::elastic::tls'
 
   class { 'profile::elastic::config':
     role         => 'master, remote_cluster_client',

--- a/environments/development/modules/profile/templates/elasticsearch.yml.erb
+++ b/environments/development/modules/profile/templates/elasticsearch.yml.erb
@@ -24,6 +24,11 @@ xpack.security.http.ssl.enabled: false
 xpack.security.transport.ssl.enabled: true
 xpack.security.transport.ssl.key: "/etc/elasticsearch/letsencrypt/privkey.pem"
 xpack.security.transport.ssl.certificate: "/etc/elasticsearch/letsencrypt/fullchain.pem"
+xpack.security.transport.ssl.certificate_authorities:
+  - /etc/elasticsearch/letsencrypt/chain.pem
+  - /etc/elasticsearch/tls/ca.cert
+  - /etc/elasticsearch/tls/ISRG_Root_X1.crt
+  - /etc/elasticsearch/tls/ISRG_Root_X2.crt
 xpack.security.transport.ssl.verification_mode: certificate
 
 xpack.security.authc:


### PR DESCRIPTION
The self-signed certificate is created but Elastic still uses let's encrypt certificate.