### PR TITLE
Find SSH service name dependin on Ubuntu OS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+puppet-code (0.1.0-1build176) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Thu, 06 Mar 2025 22:07:41 +0000
+
+puppet-code (0.1.0-1build175) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Thu, 06 Mar 2025 22:07:04 +0000
+
 puppet-code (0.1.0-1build174) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/jumphost.pp
+++ b/environments/development/modules/profile/manifests/jumphost.pp
@@ -2,6 +2,11 @@
 class profile::jumphost () {
   include 'profile::echo'
 
+  $ssh_service = ($facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['major'] == '24.04') ? {
+    true  => 'ssh',
+    false => 'sshd',
+  }
+
   $packages = {
     'pdsh' => present,
   }
@@ -18,12 +23,12 @@ class profile::jumphost () {
 
   package { 'openssh-server':
     ensure => latest,
-    notify => Service[sshd],
+    notify => Service[$ssh_service],
   }
 
-  service { 'sshd':
+  service { $ssh_service:
     ensure  => running,
-    require => Package[openssh-server],
+    require => Package['openssh-server'],
   }
 
 }


### PR DESCRIPTION
In older Ubuntu version before noble, the service was called sshd.
In Ubuntu noble it's called ssh.

Thank you, Canonical.
