### PR TITLE
[github_runner] Check instance lifecycle state before starting actions runner

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build198) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sun, 04 May 2025 22:41:00 +0000
+
 puppet-code (0.1.0-1build197) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/github_runner/service.pp
+++ b/environments/development/modules/profile/manifests/github_runner/service.pp
@@ -14,6 +14,7 @@ class profile::github_runner::service (
   $github_runner_user = $user
   $github_runner_group = $group
   $systemd_file = '/etc/systemd/system/actions-runner.service'
+  $start_script = '/usr/local/bin/start-actions-runner.sh'
   $env_file = "${runner_package_directory}/.env"
   $cleanup_path = '/usr/local/bin/gha_cleanup.sh'
 
@@ -46,6 +47,14 @@ class profile::github_runner::service (
     mode   => '0755',
   }
 
+  file { $start_script:
+    ensure  => file,
+    content => template('profile/github_runner/start-actions-runner.sh.erb'),
+    owner   => $user,
+    group   => $group,
+    mode    => '0755',
+  }
+
   file { $systemd_file:
     ensure  => file,
     content => template('profile/github_runner/actions-runner.service.erb'),
@@ -64,6 +73,7 @@ class profile::github_runner::service (
     ensure  => running,
     require => [
       File[$systemd_file],
+      File[$start_script],
       File[$env_file],
       Exec['daemon-reload'],
     ]

--- a/environments/development/modules/profile/templates/github_runner/actions-runner.service.erb
+++ b/environments/development/modules/profile/templates/github_runner/actions-runner.service.erb
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=<%= @runner_package_directory %>/run.sh
+ExecStart=<%= @start_script %>
 WorkingDirectory=<%= @runner_package_directory %>
 User=<%= @github_runner_user %>
 Group=<%= @github_runner_group %>

--- a/environments/development/modules/profile/templates/github_runner/start-actions-runner.sh.erb
+++ b/environments/development/modules/profile/templates/github_runner/start-actions-runner.sh.erb
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu
+
+while true
+do
+  state="$(aws autoscaling describe-auto-scaling-instances --instance-ids "$(ec2metadata --instance-id)" | jq -r .AutoScalingInstances[0].LifecycleState)"
+  if [[ "$state" == "InService" ]]; then
+    break
+  else
+    echo "The instance in state $state. Waiting."
+    sleep 5
+  fi
+done
+
+# Start actions-runner
+<%= @runner_package_directory %>/run.sh


### PR DESCRIPTION
When an instance enters `Warmed:Pending:Wait` state, it started actions runner and it could pick up a job.
This is undesirable, because the instance goes into "Warmed:Hibernated" and the job won't complete until the instance comes back.
It's impossible to set Scale-in protection, too because the instance isn't a part of ASG yet.

So the action-runner start script checks the lifecycle state and starts the runner only after it's InService i.e. after the instance joins the ASG from the warm pool.