### PR TITLE
[elasticsearch]: master node performs data role during bootstrap

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+puppet-code (0.1.0-1build207) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 21 May 2025 02:03:16 +0000
+
+puppet-code (0.1.0-1build206) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 21 May 2025 02:02:35 +0000
+
 puppet-code (0.1.0-1build205) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+puppet-code (0.1.0-1build205) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 21 May 2025 01:56:23 +0000
+
+puppet-code (0.1.0-1build204) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 21 May 2025 01:55:45 +0000
+
+puppet-code (0.1.0-1build203) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 21 May 2025 01:55:33 +0000
+
 puppet-code (0.1.0-1build202) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/elastic_master.pp
+++ b/environments/development/modules/profile/manifests/elastic_master.pp
@@ -6,7 +6,12 @@ class profile::elastic_master () {
   include 'profile::elastic::prometheus'
   include 'profile::elastic::tls'
 
+  $role = $facts['elasticsearch']['bootstrap_cluster'] ? {
+    true  => 'master, remote_cluster_client, data',
+    false => 'master, remote_cluster_client',
+  }
+
   class { 'profile::elastic::config':
-    role         => 'master, remote_cluster_client',
+    role => $role,
   }
 }


### PR DESCRIPTION
There was a race condition.
During bootstrapping a cluser, elastic wants to create some system
indexes. Before it does so, the cluster is green and the Terraform
module proceeded with creating data nodes. But if the cluster became
red, Terraform didn't proceed with the data nodes and failed.

Now when a sigle master node bootstraps a cluster, it also is a data
node. The cluster will be yellow, but that's enough for a healthcheck.
