### PR TITLE
Stop unattended-upgrades service on elastic nodes in sandbox and dev

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build224) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 16 Jul 2025 00:01:46 +0000
+
 puppet-code (0.1.0-1build223) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/elastic/service.pp
+++ b/environments/development/modules/profile/manifests/elastic/service.pp
@@ -50,6 +50,10 @@ class profile::elastic::service (
     ]
   }
 
+  service { 'unattended-upgrades.service':
+    ensure => stopped,
+  }
+
   # If node is about to be replaced by instance refresh
   # decommission it, wait until Elasticsearch moves shards out,
   # and complete a lifecycle hook.

--- a/environments/sandbox/modules/profile/manifests/elastic/service.pp
+++ b/environments/sandbox/modules/profile/manifests/elastic/service.pp
@@ -50,6 +50,10 @@ class profile::elastic::service (
     ]
   }
 
+  service { 'unattended-upgrades.service':
+    ensure => stopped,
+  }
+
   # If node is about to be replaced by instance refresh
   # decommission it, wait until Elasticsearch moves shards out,
   # and complete a lifecycle hook.


### PR DESCRIPTION
It can lead to uncontrolled restart. For vulnerabilities, the cluster
depends on instance refresh.
