### PR TITLE
[development] Fix openvpn_server profile for easy-rsa 3.1 version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+puppet-code (0.1.0-1build226) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Mon, 11 Aug 2025 22:01:23 +0000
+
+puppet-code (0.1.0-1build225) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Mon, 11 Aug 2025 22:01:05 +0000
+
 puppet-code (0.1.0-1build224) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build227) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Mon, 11 Aug 2025 22:04:15 +0000
+
 puppet-code (0.1.0-1build226) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build202) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Mon, 11 Aug 2025 21:24:41 +0000
+
 puppet-code (0.1.0-1build201) jammy; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/openvpn_server.pp
+++ b/environments/development/modules/profile/manifests/openvpn_server.pp
@@ -9,7 +9,6 @@ class profile::openvpn_server (
   $openvpn_easyrsa_req_org = lookup('profile::openvpn_server::openvpn_easyrsa_req_org', undef, undef, 'InfraHouse Inc.' ),
   $openvpn_easyrsa_req_email = lookup('profile::openvpn_server::openvpn_easyrsa_req_email', undef, undef, 'security@infrahouse.com' ),
   $openvpn_easyrsa_req_ou = lookup('profile::openvpn_server::openvpn_easyrsa_req_ou', undef, undef, 'Security Organization' ),
-  $openvpn_easyrsa_req_cn = lookup('profile::openvpn_server::openvpn_easyrsa_req_cn', undef, undef, 'InfraHouse OpenVPN Root CA' ),
   $openvpn_topology = lookup('profile::openvpn_server::openvpn_topology', undef, undef, 'net30' ),
   $openvpn_network = lookup('profile::openvpn_server::openvpn_network', undef, undef, '172.16.0.0' ),
   $openvpn_netmask = lookup('profile::openvpn_server::openvpn_netmask', undef, undef, '255.255.0.0' ),
@@ -31,7 +30,6 @@ class profile::openvpn_server (
     openvpn_easyrsa_req_org      => $openvpn_easyrsa_req_org,
     openvpn_easyrsa_req_email    => $openvpn_easyrsa_req_email,
     openvpn_easyrsa_req_ou       => $openvpn_easyrsa_req_ou,
-    openvpn_easyrsa_req_cn       => $openvpn_easyrsa_req_cn,
   }
 
   class { 'profile::openvpn_server::service':

--- a/environments/development/modules/profile/manifests/openvpn_server/config.pp
+++ b/environments/development/modules/profile/manifests/openvpn_server/config.pp
@@ -8,7 +8,6 @@ class profile::openvpn_server::config (
   String $openvpn_easyrsa_req_org,
   String $openvpn_easyrsa_req_email,
   String $openvpn_easyrsa_req_ou,
-  String $openvpn_easyrsa_req_cn,
   String $openvpn_topology,
   String $openvpn_network,
   String $openvpn_netmask,

--- a/environments/development/modules/profile/manifests/openvpn_server/packages.pp
+++ b/environments/development/modules/profile/manifests/openvpn_server/packages.pp
@@ -12,7 +12,8 @@ class profile::openvpn_server::packages (
   }
 
   package { 'easy-rsa':
-    ensure => '3.1.7-2'
+    ensure  => '3.1.7-2',
+    require => Mount[$openvp_config_directory],
   }
 
 }

--- a/environments/development/modules/profile/manifests/openvpn_server/packages.pp
+++ b/environments/development/modules/profile/manifests/openvpn_server/packages.pp
@@ -6,10 +6,13 @@ class profile::openvpn_server::packages (
   package { [
     'openvpn',
     'openssl',
-    'easy-rsa',
   ]:
     ensure  => present,
     require => Mount[$openvp_config_directory]
+  }
+
+  package { 'easy-rsa':
+    ensure => '3.1.7-2'
   }
 
 }

--- a/environments/development/modules/profile/templates/openvpn_server/vars.erb
+++ b/environments/development/modules/profile/templates/openvpn_server/vars.erb
@@ -207,7 +207,7 @@ set_var EASYRSA_NO_PASS true
 # This is best left alone. Interactively you will set this manually, and BATCH
 # callers are expected to set this themselves.
 
-set_var EASYRSA_REQ_CN		"<%= @openvpn_easyrsa_req_cn %>"
+set_var EASYRSA_REQ_CN		"ChangeMe"
 
 
 # Cryptographic digest to use.
@@ -221,4 +221,3 @@ set_var EASYRSA_REQ_CN		"<%= @openvpn_easyrsa_req_cn %>"
 # or most output. Setting this to any non-blank string enables batch mode.
 
 #set_var EASYRSA_BATCH		""
-


### PR DESCRIPTION
* easy-rsa fails when EASYRSA_REQ_CN is set to anything but ChangeMe. In future, they will remove the option altogether
* Pin easy-rsa to the current version of 3.1.7-2 because easy-rsa don't respect semantic versioning.
* All of the fixes in the development environment for ongoing testing.
*

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the `openvpn_easyrsa_req_cn` variable from the OpenVPN server profile configurations and update the `easy-rsa` package to version `3.1.7-2`.

### Why are these changes being made?

The `openvpn_easyrsa_req_cn` variable is deprecated in `easy-rsa` version 3.1, simplifying the configuration by leveraging default settings where possible. Upgrading the `easy-rsa` package ensures compatibility with the latest features and optimizations in version 3.1.7-2.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->