### PR TITLE
Give permissions to read crl.pem

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build235) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 12 Aug 2025 16:28:41 +0000
+
 puppet-code (0.1.0-1build234) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/templates/openvpn_server/server.conf.erb
+++ b/environments/development/modules/profile/templates/openvpn_server/server.conf.erb
@@ -10,7 +10,7 @@ push "tun-mtu 1387"
 ca <%= @openvp_config_directory %>/pki/ca.crt
 cert <%= @openvp_config_directory %>/pki/issued/server.crt
 key <%= @openvp_config_directory %>/pki/private/server.key  # This file should be kept secret
-crl-verify <%= @openvp_config_directory %>/pki/crl.pem
+crl-verify <%= @openvpn_crl_path %>
 
 dh <%= @openvp_config_directory %>/dh2048.pem
 topology <%= @openvpn_topology %>

--- a/environments/development/modules/profile/templates/openvpn_server/vars.erb
+++ b/environments/development/modules/profile/templates/openvpn_server/vars.erb
@@ -84,7 +84,7 @@ set_var EASYRSA_TEMP_DIR	"<%= @openvpn_easyrsa_tmp_dir %>"
 #   cn_only  - use just a CN value
 #   org      - use the "traditional" Country/Province/City/Org/OU/email/CN format
 
-set_var EASYRSA_DN	"cn_only"
+set_var EASYRSA_DN	"org"
 
 # Organizational fields (used with 'org' mode and ignored in 'cn_only' mode.)
 # These are the default values for fields which will be placed in the


### PR DESCRIPTION
openvpn runs as nobody/nogroup and couln't access 600 root owned certificate.
besides, the crl.pem isn't secret.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add permissions to access the `crl.pem` file by defining the file path, setting correct ownership, and modifying configuration templates to use a variable for the file path.

### Why are these changes being made?

These changes ensure that the `crl.pem` file is accessible with the correct permissions required by the OpenVPN server configuration, thereby maintaining proper security practices while addressing the need for dynamic file path configuration through the use of variables. Improving the consistency of file permission settings enhances overall system security and flexibility when deploying configurations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->