### PR TITLE
[sandbox] sync the openvpn_server profile to sandbox environment

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build236) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Thu, 14 Aug 2025 17:12:30 +0000
+
 puppet-code (0.1.0-1build235) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/sandbox/modules/profile/manifests/openvpn_server.pp
+++ b/environments/sandbox/modules/profile/manifests/openvpn_server.pp
@@ -9,7 +9,6 @@ class profile::openvpn_server (
   $openvpn_easyrsa_req_org = lookup('profile::openvpn_server::openvpn_easyrsa_req_org', undef, undef, 'InfraHouse Inc.' ),
   $openvpn_easyrsa_req_email = lookup('profile::openvpn_server::openvpn_easyrsa_req_email', undef, undef, 'security@infrahouse.com' ),
   $openvpn_easyrsa_req_ou = lookup('profile::openvpn_server::openvpn_easyrsa_req_ou', undef, undef, 'Security Organization' ),
-  $openvpn_easyrsa_req_cn = lookup('profile::openvpn_server::openvpn_easyrsa_req_cn', undef, undef, 'InfraHouse OpenVPN Root CA' ),
   $openvpn_topology = lookup('profile::openvpn_server::openvpn_topology', undef, undef, 'net30' ),
   $openvpn_network = lookup('profile::openvpn_server::openvpn_network', undef, undef, '172.16.0.0' ),
   $openvpn_netmask = lookup('profile::openvpn_server::openvpn_netmask', undef, undef, '255.255.0.0' ),
@@ -31,7 +30,6 @@ class profile::openvpn_server (
     openvpn_easyrsa_req_org      => $openvpn_easyrsa_req_org,
     openvpn_easyrsa_req_email    => $openvpn_easyrsa_req_email,
     openvpn_easyrsa_req_ou       => $openvpn_easyrsa_req_ou,
-    openvpn_easyrsa_req_cn       => $openvpn_easyrsa_req_cn,
   }
 
   class { 'profile::openvpn_server::service':

--- a/environments/sandbox/modules/profile/manifests/openvpn_server/config.pp
+++ b/environments/sandbox/modules/profile/manifests/openvpn_server/config.pp
@@ -8,7 +8,6 @@ class profile::openvpn_server::config (
   String $openvpn_easyrsa_req_org,
   String $openvpn_easyrsa_req_email,
   String $openvpn_easyrsa_req_ou,
-  String $openvpn_easyrsa_req_cn,
   String $openvpn_topology,
   String $openvpn_network,
   String $openvpn_netmask,
@@ -18,6 +17,7 @@ class profile::openvpn_server::config (
   $nfs_device = "${dns_name}:/"
   $openvpn_easyrsa_passin_file = "${openvp_config_directory}/ca_passphrase"
   $openvpn_easyrsa_tmp_dir = '/tmp'
+  $openvpn_crl_path = "${openvp_config_directory}/pki/crl.pem"
 
   $openvpn_routes = 'routes' in $facts['openvpn'] ? {
     true => $facts['openvpn']['routes'],
@@ -98,6 +98,13 @@ class profile::openvpn_server::config (
     ],
   }
 
+  file { "${openvp_config_directory}/pki":
+    owner   => root,
+    group   => root,
+    mode    => '0711',
+    require => Exec[generate_pki]
+  }
+
   exec { 'generate_pki':
     command => '/usr/share/easy-rsa/easyrsa init-pki',
     cwd     => $openvp_config_directory,
@@ -109,50 +116,44 @@ class profile::openvpn_server::config (
   }
 
   exec { 'generate_ca':
-    command     => "/usr/share/easy-rsa/easyrsa --vars=${openvp_config_directory}/vars build-ca",
-    cwd         => $openvp_config_directory,
-    environment => [
-      "EASYRSA_PASSIN=file:${openvpn_easyrsa_passin_file}",
-      "EASYRSA_PASSOUT=file:${openvpn_easyrsa_passin_file}",
-    ],
-    creates     => "${openvp_config_directory}/pki/private/ca.key",
-    require     => [
+    command => "/usr/share/easy-rsa/easyrsa --vars=${openvp_config_directory}/vars build-ca",
+    cwd     => $openvp_config_directory,
+    creates => "${openvp_config_directory}/pki/private/ca.key",
+    require => [
       Mount[$openvp_config_directory],
       Package[easy-rsa],
       File["${openvp_config_directory}/vars"],
-      File[$openvpn_easyrsa_passin_file],
     ]
   }
 
   exec { 'generate_server_key':
-    command     => "/usr/share/easy-rsa/easyrsa --vars=${openvp_config_directory}/vars build-server-full server nopass inline",
-    cwd         => $openvp_config_directory,
-    environment => [
-      "EASYRSA_PASSIN=file:${openvpn_easyrsa_passin_file}",
-      "EASYRSA_PASSOUT=file:${openvpn_easyrsa_passin_file}",
-    ],
-    creates     => "${openvp_config_directory}/pki/private/server.key",
-    require     => [
+    command => "/usr/share/easy-rsa/easyrsa --vars=${openvp_config_directory}/vars build-server-full server nopass inline",
+    cwd     => $openvp_config_directory,
+    creates => "${openvp_config_directory}/pki/private/server.key",
+    require => [
       Mount[$openvp_config_directory],
       Package[easy-rsa],
       File["${openvp_config_directory}/vars"],
-      File[$openvpn_easyrsa_passin_file],
     ]
   }
 
+  file { $openvpn_crl_path :
+    owner   => root,
+    group   => nogroup,
+    mode    => '0640',
+    require => Exec[generate_gen_crl]
+  }
+
   exec { 'generate_gen_crl':
-    command     => "/usr/share/easy-rsa/easyrsa --vars=${openvp_config_directory}/vars gen-crl",
-    cwd         => $openvp_config_directory,
-    environment => [
-      "EASYRSA_PASSIN=file:${openvpn_easyrsa_passin_file}",
-      "EASYRSA_PASSOUT=file:${openvpn_easyrsa_passin_file}",
-    ],
-    creates     => "${openvp_config_directory}/pki/crl.pem",
-    require     => [
+    command => "/usr/share/easy-rsa/easyrsa --vars=${openvp_config_directory}/vars gen-crl",
+    cwd     => $openvp_config_directory,
+    creates => $openvpn_crl_path,
+    require => [
       Mount[$openvp_config_directory],
       Package[easy-rsa],
       File["${openvp_config_directory}/vars"],
       File[$openvpn_easyrsa_passin_file],
+      Exec[generate_pki],
     ]
   }
 

--- a/environments/sandbox/modules/profile/manifests/openvpn_server/packages.pp
+++ b/environments/sandbox/modules/profile/manifests/openvpn_server/packages.pp
@@ -6,10 +6,14 @@ class profile::openvpn_server::packages (
   package { [
     'openvpn',
     'openssl',
-    'easy-rsa',
   ]:
     ensure  => present,
     require => Mount[$openvp_config_directory]
+  }
+
+  package { 'easy-rsa':
+    ensure  => '3.1.7-2',
+    require => Mount[$openvp_config_directory],
   }
 
 }

--- a/environments/sandbox/modules/profile/templates/openvpn_server/server.conf.erb
+++ b/environments/sandbox/modules/profile/templates/openvpn_server/server.conf.erb
@@ -10,7 +10,7 @@ push "tun-mtu 1387"
 ca <%= @openvp_config_directory %>/pki/ca.crt
 cert <%= @openvp_config_directory %>/pki/issued/server.crt
 key <%= @openvp_config_directory %>/pki/private/server.key  # This file should be kept secret
-crl-verify <%= @openvp_config_directory %>/pki/crl.pem
+crl-verify <%= @openvpn_crl_path %>
 
 dh <%= @openvp_config_directory %>/dh2048.pem
 topology <%= @openvpn_topology %>

--- a/environments/sandbox/modules/profile/templates/openvpn_server/vars.erb
+++ b/environments/sandbox/modules/profile/templates/openvpn_server/vars.erb
@@ -164,7 +164,7 @@ set_var EASYRSA_NS_COMMENT	"Easy-RSA Generated Certificate"
 set_var EASYRSA_TEMP_FILE	"$EASYRSA_TEMP_DIR/extensions.temp"
 
 set_var EASYRSA_BATCH true
-set_var EASYRSA_NO_PASS true
+set_var EASYRSA_NO_PASS 1
 # !!
 # NOTE: ADVANCED OPTIONS BELOW THIS POINT
 # PLAY WITH THEM AT YOUR OWN RISK
@@ -203,12 +203,6 @@ set_var EASYRSA_NO_PASS true
 
 #set_var EASYRSA_SSL_CONF	"$EASYRSA/openssl-easyrsa.cnf"
 
-# Default CN:
-# This is best left alone. Interactively you will set this manually, and BATCH
-# callers are expected to set this themselves.
-
-set_var EASYRSA_REQ_CN		"<%= @openvpn_easyrsa_req_cn %>"
-
 
 # Cryptographic digest to use.
 # Do not change this default unless you understand the security implications.
@@ -221,4 +215,3 @@ set_var EASYRSA_REQ_CN		"<%= @openvpn_easyrsa_req_cn %>"
 # or most output. Setting this to any non-blank string enables batch mode.
 
 #set_var EASYRSA_BATCH		""
-


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the `openvpn_easyrsa_req_cn` parameter from the OpenVPN server profile configuration in the sandbox environment and introduce management for OpenVPN CRL files including setting ownership and permissions, along with updating package management for `easy-rsa`.

### Why are these changes being made?

The `openvpn_easyrsa_req_cn` parameter was redundant and its removal simplifies the configuration, while the introduction of CRL management ensures proper handling of certificate revocation lists, addressing potential security concerns. The package management changes for `easy-rsa` ensure compatibility with the specified version, enhancing stability and reproducibility in the sandbox environment.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->