### PR TITLE
Extract action runner package as a regular user

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build238) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 19 Aug 2025 21:16:30 +0000
+
 puppet-code (0.1.0-1build237) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/github_runner/package.pp
+++ b/environments/development/modules/profile/manifests/github_runner/package.pp
@@ -22,6 +22,7 @@ class profile::github_runner::package (
 
   exec { 'extract_runner_package':
     path    => '/usr/bin',
+    user    => $package_directory_owner,
     command => "tar xf ${runner_package_full_path} -C ${runner_package_directory}",
     require => File[$runner_package_directory],
     creates => "${runner_package_directory}/config.sh",


### PR DESCRIPTION
When runs as root, tar changes ownership to ID in the archive file (which is unpredictable). Then runner registration fails.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Extract the GitHub action runner package as a regular user rather than the default user.

### Why are these changes being made?

This change enhances security by executing the package extraction as a specified user, reducing the risk of permissions issues or security vulnerabilities that may arise from running operations as a superuser. By specifying `$package_directory_owner`, we ensure the operation complies with the project's security practices and maintains correct file ownership and access rights.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->