### PR TITLE
[github_runner] sync permission fix to sandbox

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build239) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sun, 24 Aug 2025 14:18:32 +0000
+
 puppet-code (0.1.0-1build238) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/sandbox/modules/profile/manifests/github_runner/package.pp
+++ b/environments/sandbox/modules/profile/manifests/github_runner/package.pp
@@ -22,6 +22,7 @@ class profile::github_runner::package (
 
   exec { 'extract_runner_package':
     path    => '/usr/bin',
+    user    => $package_directory_owner,
     command => "tar xf ${runner_package_full_path} -C ${runner_package_directory}",
     require => File[$runner_package_directory],
     creates => "${runner_package_directory}/config.sh",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add user permission to the 'extract_runner_package' exec resource in the GitHub Runner Puppet manifest for the sandbox environment.

### Why are these changes being made?

This change ensures that the 'extract_runner_package' command runs with the appropriate user permissions, aligning execution with user ownership requirements and preventing potential permission errors during the extraction process. It addresses an oversight in the sandbox environment configuration without altering other environment settings.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->