### PR TITLE
[github_runner] sync permission fix to global

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build240) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sun, 24 Aug 2025 14:41:38 +0000
+
 puppet-code (0.1.0-1build239) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/manifests/github_runner/package.pp
+++ b/modules/profile/manifests/github_runner/package.pp
@@ -22,6 +22,7 @@ class profile::github_runner::package (
 
   exec { 'extract_runner_package':
     path    => '/usr/bin',
+    user    => $package_directory_owner,
     command => "tar xf ${runner_package_full_path} -C ${runner_package_directory}",
     require => File[$runner_package_directory],
     creates => "${runner_package_directory}/config.sh",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a user parameter to the 'extract_runner_package' exec resource to ensure that the package extraction is conducted with the correct permissions.

### Why are these changes being made?

These changes are necessary to synchronize permission settings for GitHub Runner across the global configuration. This allows the extraction process to respect ownership settings, thereby avoiding permission-related errors during package deployment.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->