### PR TITLE
Fix audit event loss and CloudWatch ACL permissions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build249) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Fri, 19 Dec 2025 15:41:16 +0000
+
 puppet-code (0.1.0-1build248) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/auditd.pp
+++ b/environments/development/modules/profile/manifests/auditd.pp
@@ -1,5 +1,22 @@
 # Provides comprehensive system auditing for SOC2/ISO27001 compliance
-class profile::auditd {
+#
+# @param log_file Path to the audit log file
+# @param log_file_mode File permissions for the audit log (e.g., '0640')
+# @param log_file_owner Owner of the audit log file
+# @param log_file_group Group owner of the audit log file
+#
+# @example Override via Hiera
+#   profile::auditd::log_file: '/custom/audit/app.log'
+#   profile::auditd::log_file_mode: '0600'
+#   profile::auditd::log_file_owner: 'audituser'
+#   profile::auditd::log_file_group: 'auditgroup'
+#
+class profile::auditd (
+  String $log_file       = '/var/log/audit/audit.log',
+  String $log_file_mode  = '0640',
+  String $log_file_owner = 'root',
+  String $log_file_group = 'root',
+) {
 
   package { 'auditd':
     ensure => installed,
@@ -42,21 +59,40 @@ class profile::auditd {
     require => Package['auditd'],
   }
 
+  # Remove static audit.rules file (conflicts with augenrules dynamic mode)
+  file { '/etc/audit/rules.d/audit.rules':
+    ensure => absent,
+    notify => Exec['augenrules'],
+  }
+
   # Apply audit rules
   exec { 'augenrules':
     command     => '/sbin/augenrules --load',
     refreshonly => true,
-    notify      => Service['auditd'],
   }
 
   # Manage auditd service
   service { 'auditd':
-    ensure  => running,
-    enable  => true,
-    require => [
+    ensure    => running,
+    enable    => true,
+    restart   => '/usr/sbin/service auditd restart',
+    subscribe => [
+      File['/etc/audit/rules.d/00-base.rules'],
+      File['/etc/audit/rules.d/10-compliance.rules'],
+    ],
+    require   => [
       Package['auditd'],
       File['/etc/audit/auditd.conf'],
     ],
+  }
+
+  # Ensure audit log file has correct permissions (0640 for compliance)
+  file { $log_file:
+    ensure  => file,
+    owner   => $log_file_owner,
+    group   => $log_file_group,
+    mode    => $log_file_mode,
+    require => Service['auditd'],
   }
 
   # Log rotation for audit logs

--- a/environments/development/modules/profile/templates/auditd/auditd.conf.erb
+++ b/environments/development/modules/profile/templates/auditd/auditd.conf.erb
@@ -7,7 +7,7 @@ local_events = yes
 write_logs = yes
 
 # Log file location
-log_file = /var/log/audit/audit.log
+log_file = <%= @log_file %>
 
 # Log format (raw or enriched - enriched provides more detail for compliance)
 log_format = enriched

--- a/environments/development/modules/profile/templates/auditd/logrotate.erb
+++ b/environments/development/modules/profile/templates/auditd/logrotate.erb
@@ -1,13 +1,13 @@
 # Managed by Puppet
 # Logrotate configuration for audit logs
 
-/var/log/audit/*.log {
+<%= File.dirname(@log_file) %>/*.log {
     daily
     rotate 365
     compress
     delaycompress
     notifempty
-    create 0600 root root
+    create <%= @log_file_mode %> <%= @log_file_owner %> <%= @log_file_group %>
     postrotate
         /usr/sbin/service auditd rotate
     endscript

--- a/environments/development/modules/profile/templates/jumphost/check-audit-acl.sh.erb
+++ b/environments/development/modules/profile/templates/jumphost/check-audit-acl.sh.erb
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Managed by Puppet
+# Verify CloudWatch agent can read audit logs via ACLs
+
+AUDIT_LOG_FILE="<%= @audit_log_file %>"
+
+# Check if ACL exists on the log file
+if ! /usr/bin/getfacl "${AUDIT_LOG_FILE}" 2>/dev/null | /usr/bin/grep -q "user:cwagent:r-x"; then
+    echo "ACL not set on ${AUDIT_LOG_FILE}"
+    exit 1
+fi
+
+# Test if cwagent user can actually read the file
+if ! sudo -u cwagent test -r "${AUDIT_LOG_FILE}"; then
+    echo "cwagent cannot read ${AUDIT_LOG_FILE} despite ACL"
+    exit 1
+fi
+
+echo "ACLs verified: cwagent can read ${AUDIT_LOG_FILE}"
+exit 0

--- a/environments/development/modules/profile/templates/jumphost/set-audit-acl.sh.erb
+++ b/environments/development/modules/profile/templates/jumphost/set-audit-acl.sh.erb
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Managed by Puppet
+# Set ACLs on audit log directory and files for CloudWatch agent access
+
+set -e
+
+AUDIT_LOG_DIR="<%= @audit_log_dir %>"
+
+# Set ACL on existing files and directories (recursive)
+# -R: recursive, -m: modify ACL
+# u:cwagent:r-x - allow cwagent user to read and traverse
+# m::r-x - set mask to allow r-x effective permissions
+/usr/bin/setfacl -R -m u:cwagent:r-x,m::r-x "${AUDIT_LOG_DIR}"
+
+# Set default ACL for new files (inherited by files created in the future)
+# -d: default ACL
+/usr/bin/setfacl -d -m u:cwagent:r-x,m::r-x "${AUDIT_LOG_DIR}"
+
+echo "ACLs set successfully on ${AUDIT_LOG_DIR}"


### PR DESCRIPTION
Addresses critical issues found during jumphost deployment testing:
audit event loss due to immutable backlog, ACL mask blocking cwagent,
and hardcoded paths across multiple files.

- Remove conflicting /etc/audit/rules.d/audit.rules file that was
  preventing backlog_limit from updating (stuck at 8192 instead of 65536)
- Change service notification strategy: use subscribe instead of notify
  to ensure auditd restarts when rule files change (backlog_limit is
  immutable and only set at service start)
- Backlog now correctly updates to 65536, preventing the 39k+ events
  lost that were occurring under load

- Fix ACL mask blocking effective permissions: explicitly set m::r-x
  in setfacl commands so cwagent can actually read despite ACL being set
- Refactor complex inline setfacl/getfacl commands into separate scripts:
  * set-audit-acl.sh.erb - Sets ACLs with proper mask on directory and files
  * check-audit-acl.sh.erb - Verifies ACL exists and cwagent can read
- Change unless condition to check actual log file instead of directory
  (auditd creates new files that don't inherit default ACLs properly)
- Add Class['sudo'] dependency (was causing duplicate package declaration)

- Add parameters to profile::auditd for log file path and permissions
  * log_file, log_file_mode, log_file_owner, log_file_group
- Add audit_log_file parameter to profile::jumphost::cloudwatch_agent
- Update templates to use variables instead of hardcoded paths:
  * auditd.conf.erb uses <%= @log_file %>
  * logrotate.erb uses <%= @log_file_mode %>, <%= @log_file_owner %>, etc.
  * ACL scripts use <%= @audit_log_dir %> and <%= @audit_log_file %>
- Manage log file permissions explicitly via Puppet file resource

- Add file resource to manage /var/log/audit/audit.log permissions (0640)
- Ensures compliance requirement met even when auditd recreates file
- Works alongside ACL to allow both root and cwagent access

- Add SSH brute force attack investigation section to auditd-operations.md
  with detection commands, risk assessment framework, and mitigation steps

All checks passing on jumphost:
- backlog_limit: 65536 (was 8192)
- rate_limit: 0 (unlimited)
- lost: 0 (no event loss)
- cwagent can read: YES
- aureport: no permission warnings
- 114 audit rules loaded

Fixes audit event loss issue and enables CloudWatch Logs shipping
of audit logs for SOC2/ISO27001 compliance monitoring.
