### PR TITLE
Improve FailedLogins metric pattern to catch all auth failures

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build253) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sat, 20 Dec 2025 15:01:25 +0000
+
 puppet-code (0.1.0-1build252) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/templates/jumphost/publish-jumphost-metrics.sh.erb
+++ b/environments/development/modules/profile/templates/jumphost/publish-jumphost-metrics.sh.erb
@@ -94,16 +94,16 @@ check_failed_logins() {
     previous_timestamp=$(cat "${state_file}" 2>/dev/null || echo "0")
 
     # Count failed login attempts since last check
-    # Look in auth.log for failed password attempts
+    # Matches: "Failed password" (wrong password) and "Invalid user" (nonexistent user)
     if [[ ${previous_timestamp} -eq 0 ]]; then
-        # First run - just count from last 60 seconds
-        failed_count=$(grep "Failed password" /var/log/auth.log 2>/dev/null | \
+        # First run - just count from last 100 lines
+        failed_count=$(grep -E "Failed password|Invalid user" /var/log/auth.log 2>/dev/null | \
             tail -100 | wc -l)
     else
         # Use journalctl for accurate time-based filtering
         # grep -c always outputs a count (even if 0), so no fallback needed
         failed_count=$(journalctl -u ssh.service --since="@${previous_timestamp}" 2>/dev/null | \
-            grep -c "Failed password" || true)
+            grep -cE "Failed password|Invalid user" || true)
     fi
 
     # Save current timestamp for next run


### PR DESCRIPTION
The previous pattern only matched "Failed password" which doesn't occur
on jumphosts with password authentication disabled (PasswordAuthentication no).

Changes:
- Updated grep pattern to match both "Failed password" and "Invalid user"
- "Invalid user" catches attempts with non-existent usernames (most common)
- "Failed password" catches valid users with wrong passwords (if enabled)
- More comprehensive security monitoring for SSH-key-only authentication

Testing:
- Verified on jumphost with PasswordAuthentication disabled
- Pattern now catches "Invalid user test/boo" attempts
- All 4 metrics (ServiceStatus, DiskSpaceUsed, AuditEventsLost, FailedLogins)
  confirmed publishing to CloudWatch with correct dimensions

Technical Note:
Most jumphosts use key-based authentication only. Failed login attempts
manifest as "Invalid user" rather than "Failed password" in SSH logs.
