### PR TITLE
Fix CloudWatch agent permission errors on fresh deployments

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build254) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sat, 20 Dec 2025 15:39:26 +0000
+
 puppet-code (0.1.0-1build253) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/jumphost/cloudwatch_agent.pp
+++ b/environments/development/modules/profile/manifests/jumphost/cloudwatch_agent.pp
@@ -99,7 +99,10 @@ class profile::jumphost::cloudwatch_agent (
       command     => "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
 -a fetch-config -m ec2 -s -c file:${config_file}",
       refreshonly => true,
-      require     => File[$config_file],
+      require     => [
+        File[$config_file],
+        User['cwagent'],
+      ],
     }
 
     # Ensure CloudWatch agent service is running
@@ -108,6 +111,7 @@ class profile::jumphost::cloudwatch_agent (
       enable  => true,
       require => [
         Package['amazon-cloudwatch-agent'],
+        User['cwagent'],
         Exec['configure-cloudwatch-agent-jumphost'],
       ],
     }


### PR DESCRIPTION
Adds User['cwagent'] dependency to ensure cwagent user has group
memberships (adm, utmp) before the CloudWatch agent service starts.

Problem:
On fresh jumphost deployments, CloudWatch agent was starting with
permission denied errors for log files (/var/log/auth.log, syslog,
kern.log, btmp). This occurred because the service started before
cwagent user was added to the adm and utmp groups.

Root Cause:
Process group memberships are captured at process start time and don't
change until the process restarts. Even though User['cwagent'] had a
notify to restart the service, there was no dependency preventing the
initial service start from happening too early.

Solution:
- Added User['cwagent'] to Exec['configure-cloudwatch-agent-jumphost']
  require list
- Added User['cwagent'] to Service['amazon-cloudwatch-agent'] require list

Now the dependency chain ensures:
  Package → User (with groups) → Config → Exec → Service

The service starts only after cwagent has the correct group memberships,
eliminating permission errors on first run.

Tested:
- Verified on fresh deployment (ip-10-1-101-116)
- No permission denied errors in agent logs
- Logs shipping successfully from first Puppet run
