### PR TITLE
Use CloudWatch namespace from Terraform facts instead of hardcoding

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build255) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sat, 20 Dec 2025 16:43:13 +0000
+
 puppet-code (0.1.0-1build254) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/jumphost/cloudwatch_agent.pp
+++ b/environments/development/modules/profile/manifests/jumphost/cloudwatch_agent.pp
@@ -10,6 +10,7 @@ class profile::jumphost::cloudwatch_agent (
   if $facts['jumphost'] and $facts['jumphost']['cloudwatch_log_group'] {
 
     $cloudwatch_log_group = $facts['jumphost']['cloudwatch_log_group']
+    $cloudwatch_namespace = $facts['jumphost']['cloudwatch_namespace']
     $config_dir = '/etc/aws'
     $config_file = "${config_dir}/amazon-cloudwatch-agent.json"
     $audit_log_dir = dirname($audit_log_file)

--- a/environments/development/modules/profile/manifests/jumphost/custom_metrics.pp
+++ b/environments/development/modules/profile/manifests/jumphost/custom_metrics.pp
@@ -11,6 +11,7 @@ class profile::jumphost::custom_metrics {
   # Variables for template
   $ec2_hostname = $facts['networking']['hostname']
   $region = $facts['ec2_metadata']['placement']['region']
+  $cloudwatch_namespace = $facts['jumphost']['cloudwatch_namespace']
   # $environment is a built-in Puppet variable, available in template scope
 
   # Deploy metrics collection script

--- a/environments/development/modules/profile/templates/jumphost/amazon-cloudwatch-agent.json.erb
+++ b/environments/development/modules/profile/templates/jumphost/amazon-cloudwatch-agent.json.erb
@@ -69,7 +69,7 @@
     "log_stream_name": "{instance_id}/default"
   },
   "metrics": {
-    "namespace": "Jumphost/System",
+    "namespace": "<%= @cloudwatch_namespace %>",
     "metrics_collected": {
       "procstat": [
         {

--- a/environments/development/modules/profile/templates/jumphost/publish-jumphost-metrics.sh.erb
+++ b/environments/development/modules/profile/templates/jumphost/publish-jumphost-metrics.sh.erb
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration
-NAMESPACE="Jumphost/System"
+NAMESPACE="<%= @cloudwatch_namespace %>"
 REGION="<%= @region %>"
 HOSTNAME="<%= @ec2_hostname %>"
 ENVIRONMENT="<%= @environment %>"


### PR DESCRIPTION
Replace hardcoded "Jumphost/System" namespace with dynamic value from
$facts['jumphost']['cloudwatch_namespace'] passed by Terraform. This
makes the CloudWatch namespace configurable per environment/deployment
without requiring Puppet code changes.

Changes:
- Add $cloudwatch_namespace variable in cloudwatch_agent.pp and custom_metrics.pp
- Update amazon-cloudwatch-agent.json.erb to use <%= @cloudwatch_namespace %>
- Update publish-jumphost-metrics.sh.erb to use <%= @cloudwatch_namespace %>

The namespace is now controlled via Terraform's cloudwatch_namespace variable
and passed to Puppet as a custom fact.
