### PR TITLE
Fix CloudWatch agent losing audit log access after logrotate

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+puppet-code (0.1.0-1build259) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 23 Dec 2025 00:27:58 +0000
+
+puppet-code (0.1.0-1build258) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Tue, 23 Dec 2025 00:27:36 +0000
+
 puppet-code (0.1.0-1build257) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/templates/auditd/logrotate.erb
+++ b/environments/development/modules/profile/templates/auditd/logrotate.erb
@@ -10,5 +10,9 @@
     create <%= @log_file_mode %> <%= @log_file_owner %> <%= @log_file_group %>
     postrotate
         /usr/sbin/service auditd rotate
+        # Restore ACLs if CloudWatch agent is configured
+        if [ -x /usr/local/bin/set-audit-acl ]; then
+            /usr/local/bin/set-audit-acl
+        fi
     endscript
 }

--- a/environments/sandbox/modules/profile/templates/auditd/logrotate.erb
+++ b/environments/sandbox/modules/profile/templates/auditd/logrotate.erb
@@ -10,5 +10,9 @@
     create <%= @log_file_mode %> <%= @log_file_owner %> <%= @log_file_group %>
     postrotate
         /usr/sbin/service auditd rotate
+        # Restore ACLs if CloudWatch agent is configured
+        if [ -x /usr/local/bin/set-audit-acl ]; then
+            /usr/local/bin/set-audit-acl
+        fi
     endscript
 }

--- a/modules/profile/templates/auditd/logrotate.erb
+++ b/modules/profile/templates/auditd/logrotate.erb
@@ -10,5 +10,9 @@
     create <%= @log_file_mode %> <%= @log_file_owner %> <%= @log_file_group %>
     postrotate
         /usr/sbin/service auditd rotate
+        # Restore ACLs if CloudWatch agent is configured
+        if [ -x /usr/local/bin/set-audit-acl ]; then
+            /usr/local/bin/set-audit-acl
+        fi
     endscript
 }


### PR DESCRIPTION
The CloudWatch agent was experiencing permission errors after logrotate
rotated /var/log/audit/audit.log. When logrotate creates the new log file,
it doesn't preserve the ACLs that allow the cwagent user to read it.

Added a postrotate hook to automatically restore ACLs after rotation by
calling /usr/local/bin/set-audit-acl (if present). This ensures the
CloudWatch agent maintains continuous access to audit logs across all
log rotations.
