### PR TITLE
Fix CloudWatch agent custom dimensions not appearing in metrics

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build264) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 24 Dec 2025 00:15:02 +0000
+
 puppet-code (0.1.0-1build263) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/templates/cloudwatch_agent/amazon-cloudwatch-agent.json.erb
+++ b/environments/development/modules/profile/templates/cloudwatch_agent/amazon-cloudwatch-agent.json.erb
@@ -11,6 +11,10 @@
   The only service-specific metrics are procstat patterns.
   If service-specific metrics are needed in the future, add extra_metrics parameter.
 
+  Note: Global append_dimensions only supports AWS metadata variables
+  (ImageId, InstanceId, InstanceType, AutoScalingGroupName).
+  Custom dimensions must be added to each metric type individually.
+
   Variables:
     @cloudwatch_log_group - CloudWatch log group name
     @cloudwatch_namespace - CloudWatch metrics namespace
@@ -51,7 +55,10 @@
           "measurement": [
             "pid_count"
           ],
-          "metrics_collection_interval": 60
+          "metrics_collection_interval": 60,
+          "append_dimensions": {
+            "environment": "<%= @environment %>"
+          }
         }<%= index < @all_procstat.length - 1 ? ',' : '' %>
 <% end -%>
       ],
@@ -79,7 +86,10 @@
           }
         ],
         "metrics_collection_interval": 60,
-        "totalcpu": false
+        "totalcpu": false,
+        "append_dimensions": {
+          "environment": "<%= @environment %>"
+        }
       },
       "disk": {
         "measurement": [
@@ -97,7 +107,10 @@
         "metrics_collection_interval": 300,
         "resources": [
           "/"
-        ]
+        ],
+        "append_dimensions": {
+          "environment": "<%= @environment %>"
+        }
       },
       "diskio": {
         "measurement": [
@@ -117,7 +130,10 @@
             "unit": "Bytes"
           }
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 60,
+        "append_dimensions": {
+          "environment": "<%= @environment %>"
+        }
       },
       "mem": {
         "measurement": [
@@ -132,7 +148,10 @@
             "unit": "Bytes"
           }
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 60,
+        "append_dimensions": {
+          "environment": "<%= @environment %>"
+        }
       },
       "netstat": {
         "measurement": [
@@ -152,7 +171,10 @@
             "unit": "Count"
           }
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 60,
+        "append_dimensions": {
+          "environment": "<%= @environment %>"
+        }
       },
       "processes": {
         "measurement": [
@@ -172,7 +194,10 @@
             "unit": "Count"
           }
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 60,
+        "append_dimensions": {
+          "environment": "<%= @environment %>"
+        }
       },
       "swap": {
         "measurement": [
@@ -182,11 +207,15 @@
             "unit": "Percent"
           }
         ],
-        "metrics_collection_interval": 60
+        "metrics_collection_interval": 60,
+        "append_dimensions": {
+          "environment": "<%= @environment %>"
+        }
       }
     },
     "append_dimensions": {
-      "environment": "<%= @environment %>"
+      "InstanceId": "${aws:InstanceId}",
+      "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix `environment` dimension not appearing in CloudWatch metrics
- Add `InstanceId` and `AutoScalingGroupName` dimensions to all metrics

## Problem
The global `append_dimensions` in CloudWatch agent config only supports these AWS metadata variables:
- `${aws:InstanceId}`
- `${aws:InstanceType}`
- `${aws:ImageId}`
- `${aws:AutoScalingGroupName}`

**Any other key-value pairs are silently ignored.** Our custom `environment` dimension was not appearing in metrics.

## Solution
- Add `append_dimensions` with `environment` to each metric type individually (cpu, mem, disk, diskio, netstat, processes, swap, procstat)
- Use global `append_dimensions` for the supported AWS variables (InstanceId, AutoScalingGroupName)

## Result
All metrics will now have these dimensions:
- `InstanceId` - EC2 instance ID
- `AutoScalingGroupName` - ASG name (if applicable)
- `environment` - Puppet environment (development/sandbox/production)

## Test plan
- [ ] Deploy to development OpenVPN or Jumphost
- [ ] Verify metrics in CloudWatch have `environment` dimension
- [ ] Verify metrics have `InstanceId` dimension

