### PR TITLE
Fix audit log ACL loss by moving rotation to logrotate (development)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build265) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Fri, 26 Dec 2025 15:36:32 +0000
+
 puppet-code (0.1.0-1build264) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/templates/auditd/auditd.conf.erb
+++ b/environments/development/modules/profile/templates/auditd/auditd.conf.erb
@@ -36,8 +36,10 @@ disk_full_action = suspend
 disk_error_action = suspend
 
 # Maximum log file size (in MB)
+# Rotation is handled by logrotate, not auditd, so that postrotate hooks
+# can restore ACLs for CloudWatch agent access
 max_log_file = 50
-max_log_file_action = rotate
+max_log_file_action = ignore
 
 # Name format for multi-host environments
 name_format = hostname

--- a/environments/development/modules/profile/templates/auditd/logrotate.erb
+++ b/environments/development/modules/profile/templates/auditd/logrotate.erb
@@ -1,14 +1,17 @@
 # Managed by Puppet
 # Logrotate configuration for audit logs
+# Size-based rotation (auditd rotation is disabled to allow postrotate ACL restore)
 
 <%= File.dirname(@log_file) %>/*.log {
-    daily
-    rotate 365
+    size 50M
+    rotate 10
     compress
     delaycompress
     notifempty
+    missingok
     create <%= @log_file_mode %> <%= @log_file_owner %> <%= @log_file_group %>
     postrotate
+        # Tell auditd to reopen its log file
         /usr/sbin/service auditd rotate
         # Restore ACLs if CloudWatch agent is configured
         if [ -x /usr/local/bin/set-audit-acl ]; then


### PR DESCRIPTION
## Summary
- Disables auditd's built-in log rotation in development environment
- Moves rotation responsibility to logrotate with size-based trigger (50MB)
- Ensures postrotate hook runs to restore ACLs for CloudWatch agent

## Problem
CloudWatch agent was losing access to `/var/log/audit/audit.log` after rotation.
Auditd was rotating logs internally (every 50MB), which bypassed logrotate's
postrotate hook that restores ACLs. The fix in #215 only worked for logrotate-
triggered rotations, not auditd's own rotations.

## Test plan

_After_ the pr is merged:
- [x] Deploy to development jumphost
- [x] Verify auditd.conf has `max_log_file_action = ignore`
- [x] Verify logrotate config has `size 50M`
- [ ] Wait for rotation (or force with `logrotate -f /etc/logrotate.d/audit`)
- [ ] Confirm CloudWatch agent maintains access after rotation

