### PR TITLE
Add acl package to OpenVPN CloudWatch agent config (development)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build269) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Fri, 26 Dec 2025 19:30:24 +0000
+
 puppet-code (0.1.0-1build268) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/openvpn_server/cloudwatch_agent.pp
+++ b/environments/development/modules/profile/manifests/openvpn_server/cloudwatch_agent.pp
@@ -25,6 +25,11 @@ class profile::openvpn_server::cloudwatch_agent {
       extra_procstat       => ['openvpn'],
     }
 
+    # ACL package needed for setfacl command
+    package { 'acl':
+      ensure => installed,
+    }
+
     # Scripts to manage ACLs on OpenVPN log files
     file { '/usr/local/bin/set-openvpn-acl':
       ensure  => file,
@@ -49,6 +54,7 @@ class profile::openvpn_server::cloudwatch_agent {
       command => '/usr/local/bin/set-openvpn-acl',
       unless  => '/usr/local/bin/check-openvpn-acl',
       require => [
+        Package['acl'],
         File['/usr/local/bin/set-openvpn-acl'],
         File['/usr/local/bin/check-openvpn-acl'],
       ],


### PR DESCRIPTION
## Summary
Adds `acl` package to OpenVPN CloudWatch agent configuration

## Problem
After #221 removed the `acl` package from the base `cloudwatch_agent` class,
OpenVPN servers failed with:
/usr/local/bin/set-openvpn-acl: line 10: setfacl: command not found

## Solution
Add the `acl` package directly to `profile::openvpn_server::cloudwatch_agent`
since OpenVPN still uses ACLs for log file permissions.

