### PR TITLE
Fix jumphost custom metrics to handle missing Terraform facts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build273) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Fri, 02 Jan 2026 23:34:07 +0000
+
 puppet-code (0.1.0-1build272) noble; urgency=medium
 
   * commit event. see changes history in git log


### PR DESCRIPTION
Wrap custom_metrics configuration in a conditional check for the
jumphost fact, matching the pattern used in cloudwatch_agent.pp.

This prevents Puppet failures when the jumphost fact is not provided
by older Terraform modules that haven't been updated yet.

Benefits:
- Prevents "Operator '[]' is not applicable to an Undef Value" errors
- Avoids configuring metrics on instances without proper IAM permissions
- Eliminates unnecessary resource consumption from failed cron jobs
  running every minute without CloudWatch PutMetricData permissions
- Metrics auto-enable once Terraform module provides the fact
- Consistent defensive pattern across all jumphost CloudWatch classes

Files updated:
- environments/sandbox/modules/profile/manifests/jumphost/custom_metrics.pp
- environments/development/modules/profile/manifests/jumphost/custom_metrics.pp
- modules/profile/manifests/jumphost/custom_metrics.pp

This follows the pattern of your recent commits with:
- Imperative mood subject line
- Detailed explanation of the problem and solution
- Clear benefits
- List of affected files
