### PR TITLE
Add Percona repository Puppet profile (#233)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build276) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sun, 18 Jan 2026 18:11:05 +0000
+
 puppet-code (0.1.0-1build275) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/data/percona_server.yaml
+++ b/environments/development/data/percona_server.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - role::percona_server

--- a/environments/development/modules/profile/manifests/percona.pp
+++ b/environments/development/modules/profile/manifests/percona.pp
@@ -1,0 +1,6 @@
+# @summary: Installs Percona Server and related components
+class profile::percona () {
+
+  include 'profile::percona::repo'
+
+}

--- a/environments/development/modules/profile/manifests/percona/repo.pp
+++ b/environments/development/modules/profile/manifests/percona/repo.pp
@@ -1,0 +1,41 @@
+# @summary: Installs Percona repository using percona-release package.
+class profile::percona::repo () {
+  $release_package_url = 'https://repo.percona.com/apt/percona-release_latest.generic_all.deb'
+  $release_package_path = '/var/tmp/percona-release_latest.generic_all.deb'
+
+  package { ['gnupg2', 'curl', 'lsb-release']:
+    ensure => 'installed',
+  }
+
+  exec { 'download-percona-release':
+    path    => '/usr/bin',
+    command => "curl -o ${release_package_path} ${release_package_url}",
+    creates => $release_package_path,
+    require => Package['curl'],
+  }
+
+  exec { 'install-percona-release':
+    path    => '/usr/bin:/usr/sbin:/sbin:/bin',
+    command => "dpkg -i ${release_package_path}",
+    unless  => 'dpkg -l percona-release',
+    require => [
+      Exec['download-percona-release'],
+      Package['gnupg2'],
+      Package['lsb-release'],
+    ],
+    notify  => Exec['percona-release-setup'],
+  }
+
+  exec { 'percona-release-setup':
+    path        => '/usr/bin:/usr/sbin:/sbin:/bin',
+    command     => 'percona-release setup ps80 -y',
+    refreshonly => true,
+    notify      => Exec['update-percona-repo'],
+  }
+
+  exec { 'update-percona-repo':
+    path        => '/usr/bin',
+    command     => 'apt-get update',
+    refreshonly => true,
+  }
+}

--- a/modules/role/manifests/percona_server.pp
+++ b/modules/role/manifests/percona_server.pp
@@ -1,0 +1,7 @@
+# @summary: Puppet role for a Percona Server node
+class role::percona_server () {
+
+  include 'profile::base'
+  include 'profile::percona'
+
+}


### PR DESCRIPTION
## Summary
- Add `role::percona_server` for Percona Server nodes
- Add `profile::percona::repo` that installs Percona repository via `percona-release` package
- Add Hiera data for `percona_server` role in development environment

## Test plan
- [x] Tested on EC2 instance i-023f60a8641c67600
- [x] Verified `apt-cache policy percona-server-server` shows Percona packages available
- [x] Confirmed idempotent execution (second run makes no changes)

Closes #233

