### PR TITLE
Add Percona Server configuration and bootstrap profiles (#236)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build277) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Mon, 19 Jan 2026 01:25:51 +0000
+
 puppet-code (0.1.0-1build276) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/percona.pp
+++ b/environments/development/modules/profile/manifests/percona.pp
@@ -2,5 +2,9 @@
 class profile::percona () {
 
   include 'profile::percona::repo'
+  include 'profile::percona::packages'
+  include 'profile::percona::config'
+  include 'profile::percona::service'
+  include 'profile::percona::bootstrap'
 
 }

--- a/environments/development/modules/profile/manifests/percona/bootstrap.pp
+++ b/environments/development/modules/profile/manifests/percona/bootstrap.pp
@@ -1,0 +1,33 @@
+# @summary: Bootstraps Percona Server as master or configures as replica.
+# Creates MySQL users on master (replicas get them via replication).
+# Registers instances with NLB target groups.
+class profile::percona::bootstrap () {
+
+  $cluster_id = $facts['percona']['cluster_id']
+  $dynamodb_table = $facts['percona']['dynamodb_table']
+  $credentials_secret = $facts['percona']['credentials_secret']
+  $vpc_cidr = $facts['percona']['vpc_cidr']
+  $read_tg_arn = $facts['percona']['read_tg_arn']
+  $write_tg_arn = $facts['percona']['write_tg_arn']
+
+  $bootstrap_cmd = @("CMD"/L)
+    ih-mysql bootstrap \
+    --cluster-id ${cluster_id} \
+    --dynamodb-table ${dynamodb_table} \
+    --credentials-secret ${credentials_secret} \
+    --vpc-cidr ${vpc_cidr} \
+    --read-tg-arn ${read_tg_arn} \
+    --write-tg-arn ${write_tg_arn}
+    |-CMD
+
+  exec { 'percona-bootstrap':
+    path    => '/usr/local/bin:/usr/bin:/bin',
+    command => $bootstrap_cmd,
+    creates => '/var/lib/mysql/.bootstrapped',
+    require => [
+      Package['infrahouse-toolkit'],
+      Service['mysql'],
+    ],
+  }
+
+}

--- a/environments/development/modules/profile/manifests/percona/config.pp
+++ b/environments/development/modules/profile/manifests/percona/config.pp
@@ -1,0 +1,58 @@
+# @summary: Configures Percona Server my.cnf with GTID replication settings.
+class profile::percona::config () {
+
+  # Generate unique server-id from IP address last two octets
+  $ip_parts = split($facts['networking']['ip'], '[.]')
+  $server_id = Integer($ip_parts[2]) * 256 + Integer($ip_parts[3])
+
+  # Auto-calculate buffer pool size (75% of RAM)
+  $total_memory_mb = $facts['memory']['system']['total_bytes'] / 1024 / 1024
+  $auto_buffer_pool = "${Integer($total_memory_mb * 0.75)}M"
+
+  # Key paths - can be used by other profiles (e.g., cloudwatch)
+  $log_error = pick(
+    $facts.dig('percona', 'log_error'),
+    lookup('profile::percona::log_error', undef, undef, undef),
+    '/var/log/mysql/error.log'
+  )
+
+  # Default MySQL configuration
+  $default_config = {
+    'datadir'                        => '/var/lib/mysql',
+    'innodb_buffer_pool_size'        => $auto_buffer_pool,
+    'innodb_flush_log_at_trx_commit' => '1',
+    'innodb_log_file_size'           => '256M',
+    'log-error'                      => $log_error,
+    'max_connections'                => '500',
+    'pid-file'                       => '/var/run/mysqld/mysqld.pid',
+    'socket'                         => '/var/run/mysqld/mysqld.sock',
+    'sync_binlog'                    => '1',
+  }
+
+  # Get config from Hiera and facts
+  $hiera_config = lookup('profile::percona::mysql_config', Hash, 'hash', {})
+  $facts_config = pick($facts.dig('percona', 'mysql_config'), {})
+
+  # Merge: defaults ← hiera ← facts (facts have highest priority)
+  $mysql_config = $default_config + $hiera_config + $facts_config
+
+  # Ensure config directory exists before package install
+  file { '/etc/mysql':
+    ensure => directory,
+  }
+
+  file { '/etc/mysql/mysql.conf.d':
+    ensure  => directory,
+    require => File['/etc/mysql'],
+  }
+
+  # Config must be in place BEFORE package installs so MySQL starts with correct settings
+  # NOTE: No notify - config changes require manual/controlled restart
+  # Do NOT auto-restart a master with active connections
+  file { '/etc/mysql/mysql.conf.d/mysqld.cnf':
+    ensure  => file,
+    content => template('profile/percona/mysqld.cnf.erb'),
+    require => File['/etc/mysql/mysql.conf.d'],
+  }
+
+}

--- a/environments/development/modules/profile/manifests/percona/packages.pp
+++ b/environments/development/modules/profile/manifests/percona/packages.pp
@@ -1,0 +1,18 @@
+# @summary: Installs Percona Server packages.
+class profile::percona::packages () {
+
+  # Config must be in place before package install so MySQL starts correctly
+  package { 'percona-server-server':
+    ensure  => 'installed',
+    require => [
+      Class['profile::percona::repo'],
+      Class['profile::percona::config'],
+    ],
+  }
+
+  package { 'percona-server-client':
+    ensure  => 'installed',
+    require => Class['profile::percona::repo'],
+  }
+
+}

--- a/environments/development/modules/profile/manifests/percona/service.pp
+++ b/environments/development/modules/profile/manifests/percona/service.pp
@@ -1,0 +1,10 @@
+# @summary: Manages Percona Server MySQL service.
+class profile::percona::service () {
+
+  service { 'mysql':
+    ensure  => running,
+    enable  => true,
+    require => Package['percona-server-server'],
+  }
+
+}

--- a/environments/development/modules/profile/templates/percona/mysqld.cnf.erb
+++ b/environments/development/modules/profile/templates/percona/mysqld.cnf.erb
@@ -1,0 +1,24 @@
+# Percona Server 8.0 configuration
+# Managed by Puppet - DO NOT EDIT
+
+[mysqld]
+# Unique server identifier
+server-id = <%= @server_id %>
+
+# GTID configuration (required for replication)
+gtid_mode = ON
+enforce_gtid_consistency = ON
+
+# Binary logging (required for replication)
+log_bin = mysql-bin
+binlog_format = ROW
+log_slave_updates = ON
+
+# Replication settings
+relay_log = relay-bin
+relay_log_recovery = ON
+
+# Configurable settings (from facts/hiera/defaults)
+<% @mysql_config.sort.each do |key, value| -%>
+<%= key %> = <%= value %>
+<% end -%>


### PR DESCRIPTION
## Summary
- Implements complete Percona Server configuration management
- Adds bootstrap integration with `ih-mysql` CLI from infrahouse-toolkit
- Configures MySQL with GTID replication settings for master/replica topology

## Changes
| File | Purpose |
|------|---------|
| `packages.pp` | Installs percona-server-server and client |
| `config.pp` | Configures my.cnf with GTID replication, auto-calculated buffer pool |
| `service.pp` | Manages MySQL service |
| `bootstrap.pp` | Calls `ih-mysql bootstrap` for master election and replica setup |
| `mysqld.cnf.erb` | MySQL configuration template with GTID settings |

## Bootstrap Behavior
The `ih-mysql bootstrap` command (from infrahouse-toolkit) handles:
- Master election via DynamoDB distributed lock
- MySQL user creation (repl, backup, monitor) on master only
- Replica configuration with GTID replication (users replicated automatically)
- NLB target group registration (write TG for master, read TG for all)

## Required Facts
Custom facts in `/etc/puppetlabs/facter/facts.d/custom.json`:
- `percona.cluster_id` - Unique cluster identifier
- `percona.dynamodb_table` - DynamoDB table for locking
- `percona.credentials_secret` - AWS Secrets Manager secret name
- `percona.vpc_cidr` - VPC CIDR for user host restrictions
- `percona.read_tg_arn` - Read target group ARN
- `percona.write_tg_arn` - Write target group ARN

## Test plan
- [ ] Deploy to development environment with 3 EC2 instances
- [ ] Verify first instance becomes master and creates users
- [ ] Verify second/third instances become replicas
- [ ] Verify replication is working (SHOW REPLICA STATUS)
- [ ] Verify target group registrations

