### PR TITLE
Promote graceful scale-in for actions-runner to global modules

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build303) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sun, 19 Apr 2026 16:47:45 +0000
+
 puppet-code (0.1.0-1build302) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/modules/profile/files/github_runner/gha-lifecycle-heartbeater.sh
+++ b/modules/profile/files/github_runner/gha-lifecycle-heartbeater.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# No-op unless the instance is in Terminating:Wait. Fire-and-forget.
+set -eu
+
+hook_name="${DEREGISTRATION_HOOK_NAME:-}"
+[[ -z "$hook_name" ]] && exit 0
+
+instance_id=$(ec2metadata --instance-id)
+state=$(aws autoscaling describe-auto-scaling-instances \
+        --instance-ids "$instance_id" \
+        --query 'AutoScalingInstances[0].LifecycleState' --output text 2>/dev/null || echo "")
+
+if [[ "$state" == "Terminating:Wait" ]]; then
+  asg=$(ih-ec2 tags | jq -r '."aws:autoscaling:groupName"')
+  aws autoscaling record-lifecycle-action-heartbeat \
+    --auto-scaling-group-name "$asg" \
+    --lifecycle-hook-name "$hook_name" \
+    --instance-id "$instance_id"
+fi

--- a/modules/profile/files/github_runner/gha-lifecycle-heartbeater.timer
+++ b/modules/profile/files/github_runner/gha-lifecycle-heartbeater.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Every 10 minutes, heartbeat the deregistration lifecycle hook if needed
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+Unit=gha-lifecycle-heartbeater.service
+
+[Install]
+WantedBy=timers.target

--- a/modules/profile/files/github_runner/gha-on-runner-exit.sh
+++ b/modules/profile/files/github_runner/gha-on-runner-exit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Called by systemd's ExecStopPost when actions-runner.service stops.
+# If the ASG wants this instance terminated, complete the deregistration
+# lifecycle hook now so the instance can go away cleanly.
+set -eu
+
+hook_name="${DEREGISTRATION_HOOK_NAME:-}"
+[[ -z "$hook_name" ]] && exit 0
+
+instance_id=$(ec2metadata --instance-id)
+state=$(aws autoscaling describe-auto-scaling-instances \
+        --instance-ids "$instance_id" \
+        --query 'AutoScalingInstances[0].LifecycleState' --output text 2>/dev/null || echo "")
+
+case "$state" in
+  Terminating:Wait|Terminating:Proceed)
+    /usr/local/bin/ih-aws autoscaling complete --result CONTINUE "$hook_name"
+    ;;
+esac

--- a/modules/profile/files/github_runner/gha_prerun.sh
+++ b/modules/profile/files/github_runner/gha_prerun.sh
@@ -3,4 +3,22 @@
 set -eu
 
 sudo chown -R "$USER" "$GITHUB_WORKSPACE"
-/usr/local/bin/ih-aws autoscaling scale-in enable-protection
+
+# Try to protect this instance from scale-in. If the ASG has already
+# decided to terminate us, protection is meaningless; let the job run
+# and let the deprovisioning path finish us off cleanly.
+if ! /usr/local/bin/ih-aws autoscaling scale-in enable-protection 2>/tmp/prerun_err; then
+  instance_id=$(ec2metadata --instance-id)
+  state=$(aws autoscaling describe-auto-scaling-instances \
+          --instance-ids "$instance_id" \
+          --query 'AutoScalingInstances[0].LifecycleState' --output text 2>/dev/null || echo "")
+  case "$state" in
+    Terminating:Wait|Terminating:Proceed)
+      echo "prerun: instance is in $state — skipping protect, job will proceed" >&2
+      ;;
+    *)
+      cat /tmp/prerun_err >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/modules/profile/manifests/github_runner/register.pp
+++ b/modules/profile/manifests/github_runner/register.pp
@@ -25,6 +25,14 @@ class profile::github_runner::register (
     creates => "${runner_package_directory}/.credentials",
     require => [
       Exec[extract_runner_package]
-    ]
+    ],
+    notify  => Exec['delete_registration_token'],
+  }
+
+  exec { 'delete_registration_token':
+    user        => $user,
+    path        => '/usr/bin:/usr/local/bin',
+    command     => "aws secretsmanager delete-secret --secret-id ${token_secret} --force-delete-without-recovery",
+    refreshonly => true,
   }
 }

--- a/modules/profile/manifests/github_runner/service.pp
+++ b/modules/profile/manifests/github_runner/service.pp
@@ -18,6 +18,11 @@ class profile::github_runner::service (
   $env_file = "${runner_package_directory}/.env"
   $prerun_path = '/usr/local/bin/gha_prerun.sh'
   $postrun_path = '/usr/local/bin/gha_postrun.sh'
+  $on_exit_path = '/usr/local/bin/gha-on-runner-exit.sh'
+  $heartbeater_script = '/usr/local/bin/gha-lifecycle-heartbeater.sh'
+  $heartbeater_service = '/etc/systemd/system/gha-lifecycle-heartbeater.service'
+  $heartbeater_timer = '/etc/systemd/system/gha-lifecycle-heartbeater.timer'
+  $deregistration_hookname = pick_default($facts['deregistration_hookname'], '')
 
   file { $env_file:
     ensure  => file,
@@ -56,6 +61,22 @@ class profile::github_runner::service (
     mode   => '0755',
   }
 
+  file { $on_exit_path:
+    ensure => file,
+    source => 'puppet:///modules/profile/github_runner/gha-on-runner-exit.sh',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  file { $heartbeater_script:
+    ensure => file,
+    source => 'puppet:///modules/profile/github_runner/gha-lifecycle-heartbeater.sh',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
   file { $start_script:
     ensure  => file,
     content => template('profile/github_runner/start-actions-runner.sh.erb'),
@@ -73,6 +94,24 @@ class profile::github_runner::service (
     notify  => Exec['daemon-reload'],
   }
 
+  file { $heartbeater_service:
+    ensure  => file,
+    content => template('profile/github_runner/gha-lifecycle-heartbeater.service.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    notify  => Exec['daemon-reload'],
+  }
+
+  file { $heartbeater_timer:
+    ensure => file,
+    source => 'puppet:///modules/profile/github_runner/gha-lifecycle-heartbeater.timer',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    notify => Exec['daemon-reload'],
+  }
+
   exec { 'daemon-reload':
     command     => '/usr/bin/systemctl daemon-reload',
     refreshonly => true,
@@ -84,6 +123,17 @@ class profile::github_runner::service (
       File[$systemd_file],
       File[$start_script],
       File[$env_file],
+      Exec['daemon-reload'],
+    ]
+  }
+
+  service { 'gha-lifecycle-heartbeater.timer':
+    ensure  => running,
+    enable  => true,
+    require => [
+      File[$heartbeater_script],
+      File[$heartbeater_service],
+      File[$heartbeater_timer],
       Exec['daemon-reload'],
     ]
   }

--- a/modules/profile/templates/github_runner/actions-runner.service.erb
+++ b/modules/profile/templates/github_runner/actions-runner.service.erb
@@ -1,13 +1,19 @@
 [Unit]
 Description=GitHub self-hosted runner
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 ExecStart=<%= @start_script %>
+ExecStopPost=/usr/local/bin/gha-on-runner-exit.sh
+Environment=DEREGISTRATION_HOOK_NAME=<%= @deregistration_hookname %>
 WorkingDirectory=<%= @runner_package_directory %>
 User=<%= @github_runner_user %>
 Group=<%= @github_runner_group %>
+KillMode=process
+KillSignal=SIGTERM
+TimeoutStopSec=21600
 Restart=on-failure
 
 [Install]

--- a/modules/profile/templates/github_runner/gha-lifecycle-heartbeater.service.erb
+++ b/modules/profile/templates/github_runner/gha-lifecycle-heartbeater.service.erb
@@ -1,0 +1,8 @@
+[Unit]
+Description=Extend deregistration lifecycle hook while this instance is terminating
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/gha-lifecycle-heartbeater.sh
+Environment=DEREGISTRATION_HOOK_NAME=<%= @deregistration_hookname %>
+Restart=on-failure

--- a/modules/profile/templates/github_runner/start-actions-runner.sh.erb
+++ b/modules/profile/templates/github_runner/start-actions-runner.sh.erb
@@ -2,9 +2,13 @@
 
 set -eu
 
+instance_id=$(ec2metadata --instance-id)
+
 while true
 do
-  state="$(aws autoscaling describe-auto-scaling-instances --instance-ids "$(ec2metadata --instance-id)" | jq -r .AutoScalingInstances[0].LifecycleState)"
+  state=$(aws autoscaling describe-auto-scaling-instances \
+          --instance-ids "$instance_id" \
+          --query 'AutoScalingInstances[0].LifecycleState' --output text)
   if [[ "$state" == "InService" ]]; then
     break
   else
@@ -13,5 +17,4 @@ do
   fi
 done
 
-# Start actions-runner
-<%= @runner_package_directory %>/run.sh
+exec <%= @runner_package_directory %>/bin/runsvc.sh


### PR DESCRIPTION
## Summary
- Promotes the graceful scale-in implementation from `environments/sandbox/modules/profile/github_runner/` to the top-level `modules/profile/github_runner/` (follow-up to #265 dev, #268 sandbox).
- Copies the 9 files listed in #267: 4 new (`gha-lifecycle-heartbeater.sh`, `gha-lifecycle-heartbeater.timer`, `gha-on-runner-exit.sh`, `gha-lifecycle-heartbeater.service.erb`) and 5 updated (`gha_prerun.sh`, `register.pp`, `service.pp`, `actions-runner.service.erb`, `start-actions-runner.sh.erb`).
- After merge, `modules/profile/github_runner/` is byte-identical to the sandbox copy; production and other environments without overrides pick it up.

Closes #267.

## Deployment strategy
Same gradual, Puppet-first approach used for sandbox in #268:

1. Merge + deploy this PR to production runners.
2. Observe old-Terraform / new-Puppet behavior in prod: characterize `delete_registration_token` under old IAM and the missing-fact path for `deregistration_hookname`.
3. Then roll out `terraform-aws-actions-runner` Part 1 (new fact + IAM) to remaining production AWS accounts.
4. Validate the full happy path across production.

Note: the environment-specific copies in `environments/development/` and `environments/sandbox/` are deliberately kept for now so their bake periods remain pinned to the version they were validated on. Cleanup of those overrides is out of scope for this PR.

## Test plan
### Phase 1 — old-Terraform / new-Puppet (this PR)
- [x] `puppet-lint --fail-on-warnings` clean on global profile module (done locally).
- [ ] Heartbeater service/timer come up on production runners without crashing.
- [ ] `delete_registration_token` behavior under old IAM characterized — fails loudly but runner still terminates cleanly.
- [ ] Runs with `deregistration_hookname` fact absent do not cause fatal errors in Puppet or lifecycle scripts.
- [ ] No stuck `Terminating:Wait` instances beyond `heartbeat_timeout` that would not also have been stuck pre-change.

### Phase 2 — after Terraform Part 1 is applied to all production accounts
- [ ] No `ValidationError` on `SetInstanceProtection` in CloudTrail during production scale-in events.
- [ ] No stuck `Terminating:Wait` instances beyond `heartbeat_timeout`.
- [ ] `delete_registration_token` succeeds (no `AccessDeniedException`).
- [ ] Full success criteria in `.claude/plans/actions-runner-scale-in-race.md` verified across production runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)