### PR TITLE
Manage ssm-user sudoers in production and sandbox

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build304) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 22 Apr 2026 17:11:08 +0000
+
 puppet-code (0.1.0-1build303) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/production/data/common.yaml
+++ b/environments/production/data/common.yaml
@@ -2,3 +2,6 @@ sudo::configs:
   'admin':
     'content'   : '%admin ALL=(ALL) NOPASSWD: ALL'
     'priority'  : 10
+  'ssm-user':
+    'content'   : 'ssm-user ALL=(ALL) NOPASSWD: ALL'
+    'priority'  : 10

--- a/environments/sandbox/data/common.yaml
+++ b/environments/sandbox/data/common.yaml
@@ -2,3 +2,6 @@ sudo::configs:
   'admin':
     'content'   : '%admin ALL=(ALL) NOPASSWD: ALL'
     'priority'  : 10
+  'ssm-user':
+    'content'   : 'ssm-user ALL=(ALL) NOPASSWD: ALL'
+    'priority'  : 10


### PR DESCRIPTION
## Summary
- The `ssm-user` entry in `sudo::configs` was only declared in `development`'s hiera data. Because `saz/sudo` defaults to `purge => true`, puppet wipes SSM agent's own `/etc/sudoers.d/ssm-agent-users` on every run — so prod and sandbox ended up with no sudo grant for `ssm-user`.
- Add the same `sudo::configs` entry to `environments/production/data/common.yaml` and `environments/sandbox/data/common.yaml` so puppet owns the grant end-to-end in all environments.

## Test plan
- [ ] Apply in sandbox and confirm `/etc/sudoers.d/ssm-user` exists with `ssm-user ALL=(ALL) NOPASSWD: ALL` and perms `0440 root:root`.
- [ ] Start an SSM session as `ssm-user` and verify `sudo -n true` succeeds.
- [ ] Promote to production after sandbox soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)