### PR TITLE
Pin TF_PLUGIN_CACHE_DIR to a predictable path on terraformer (#274)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build307) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Wed, 24 Jun 2026 22:57:31 +0000
+
 puppet-code (0.1.0-1build306) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/terraformer.pp
+++ b/environments/development/modules/profile/manifests/terraformer.pp
@@ -13,4 +13,7 @@ class profile::terraformer (
 
   # CloudWatch agent for logging and metrics
   include profile::terraformer::cloudwatch_agent
+
+  # Shared Terraform provider plugin cache at a predictable path
+  include profile::terraformer::plugin_cache
 }

--- a/environments/development/modules/profile/manifests/terraformer/plugin_cache.pp
+++ b/environments/development/modules/profile/manifests/terraformer/plugin_cache.pp
@@ -1,0 +1,51 @@
+# @summary: Shared, predictable Terraform provider plugin cache.
+#
+# Pins TF_PLUGIN_CACHE_DIR to a constant path so provider binaries are cached once
+# under a deterministic prefix (instead of per-workdir .terraform/providers paths that
+# vary run to run). This lets AWS Inspector EC2 scanning suppress the provider-binary
+# noise with a single PREFIX filter while still scanning the host's OS packages.
+#
+# Terraform does not create the cache dir itself, so we create it here.
+# See: https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
+class profile::terraformer::plugin_cache (
+  String $cache_dir   = '/var/cache/terraform/plugins',
+  String $cache_group = 'admin',
+) {
+  # ACL tooling so the admin group can share the cache (see exec below).
+  stdlib::ensure_packages(['acl'])
+
+  file { '/var/cache/terraform':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  # setgid so new entries inherit the admin group; the default ACL below adds the
+  # group-write that the umask would otherwise strip from nested dirs.
+  file { $cache_dir:
+    ensure  => directory,
+    owner   => 'root',
+    group   => $cache_group,
+    mode    => '2775',
+    require => File['/var/cache/terraform'],
+  }
+
+  # Default + access ACL so every provider dir/file terraform creates stays writable
+  # by the admin group. Idempotent via the unless guard.
+  exec { 'terraformer-plugin-cache-acl':
+    command => "setfacl -R -m d:g:${cache_group}:rwx -m g:${cache_group}:rwx ${cache_dir}",
+    path    => ['/usr/bin', '/bin'],
+    unless  => "getfacl -pc ${cache_dir} | grep -qx 'default:group:${cache_group}:rwx'",
+    require => [Package['acl'], File[$cache_dir]],
+  }
+
+  # Export the cache dir for interactive login shells; terraform reads this env var.
+  file { '/etc/profile.d/terraform-plugin-cache.sh':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => "# Managed by Puppet (profile::terraformer::plugin_cache)\nexport TF_PLUGIN_CACHE_DIR=${cache_dir}\n",
+  }
+}

--- a/environments/sandbox/modules/profile/manifests/terraformer.pp
+++ b/environments/sandbox/modules/profile/manifests/terraformer.pp
@@ -13,4 +13,7 @@ class profile::terraformer (
 
   # CloudWatch agent for logging and metrics
   include profile::terraformer::cloudwatch_agent
+
+  # Shared Terraform provider plugin cache at a predictable path
+  include profile::terraformer::plugin_cache
 }

--- a/environments/sandbox/modules/profile/manifests/terraformer/plugin_cache.pp
+++ b/environments/sandbox/modules/profile/manifests/terraformer/plugin_cache.pp
@@ -1,0 +1,51 @@
+# @summary: Shared, predictable Terraform provider plugin cache.
+#
+# Pins TF_PLUGIN_CACHE_DIR to a constant path so provider binaries are cached once
+# under a deterministic prefix (instead of per-workdir .terraform/providers paths that
+# vary run to run). This lets AWS Inspector EC2 scanning suppress the provider-binary
+# noise with a single PREFIX filter while still scanning the host's OS packages.
+#
+# Terraform does not create the cache dir itself, so we create it here.
+# See: https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
+class profile::terraformer::plugin_cache (
+  String $cache_dir   = '/var/cache/terraform/plugins',
+  String $cache_group = 'admin',
+) {
+  # ACL tooling so the admin group can share the cache (see exec below).
+  stdlib::ensure_packages(['acl'])
+
+  file { '/var/cache/terraform':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  # setgid so new entries inherit the admin group; the default ACL below adds the
+  # group-write that the umask would otherwise strip from nested dirs.
+  file { $cache_dir:
+    ensure  => directory,
+    owner   => 'root',
+    group   => $cache_group,
+    mode    => '2775',
+    require => File['/var/cache/terraform'],
+  }
+
+  # Default + access ACL so every provider dir/file terraform creates stays writable
+  # by the admin group. Idempotent via the unless guard.
+  exec { 'terraformer-plugin-cache-acl':
+    command => "setfacl -R -m d:g:${cache_group}:rwx -m g:${cache_group}:rwx ${cache_dir}",
+    path    => ['/usr/bin', '/bin'],
+    unless  => "getfacl -pc ${cache_dir} | grep -qx 'default:group:${cache_group}:rwx'",
+    require => [Package['acl'], File[$cache_dir]],
+  }
+
+  # Export the cache dir for interactive login shells; terraform reads this env var.
+  file { '/etc/profile.d/terraform-plugin-cache.sh':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => "# Managed by Puppet (profile::terraformer::plugin_cache)\nexport TF_PLUGIN_CACHE_DIR=${cache_dir}\n",
+  }
+}

--- a/modules/profile/manifests/terraformer.pp
+++ b/modules/profile/manifests/terraformer.pp
@@ -13,4 +13,7 @@ class profile::terraformer (
 
   # CloudWatch agent for logging and metrics
   include profile::terraformer::cloudwatch_agent
+
+  # Shared Terraform provider plugin cache at a predictable path
+  include profile::terraformer::plugin_cache
 }

--- a/modules/profile/manifests/terraformer/plugin_cache.pp
+++ b/modules/profile/manifests/terraformer/plugin_cache.pp
@@ -1,0 +1,51 @@
+# @summary: Shared, predictable Terraform provider plugin cache.
+#
+# Pins TF_PLUGIN_CACHE_DIR to a constant path so provider binaries are cached once
+# under a deterministic prefix (instead of per-workdir .terraform/providers paths that
+# vary run to run). This lets AWS Inspector EC2 scanning suppress the provider-binary
+# noise with a single PREFIX filter while still scanning the host's OS packages.
+#
+# Terraform does not create the cache dir itself, so we create it here.
+# See: https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
+class profile::terraformer::plugin_cache (
+  String $cache_dir   = '/var/cache/terraform/plugins',
+  String $cache_group = 'admin',
+) {
+  # ACL tooling so the admin group can share the cache (see exec below).
+  stdlib::ensure_packages(['acl'])
+
+  file { '/var/cache/terraform':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  # setgid so new entries inherit the admin group; the default ACL below adds the
+  # group-write that the umask would otherwise strip from nested dirs.
+  file { $cache_dir:
+    ensure  => directory,
+    owner   => 'root',
+    group   => $cache_group,
+    mode    => '2775',
+    require => File['/var/cache/terraform'],
+  }
+
+  # Default + access ACL so every provider dir/file terraform creates stays writable
+  # by the admin group. Idempotent via the unless guard.
+  exec { 'terraformer-plugin-cache-acl':
+    command => "setfacl -R -m d:g:${cache_group}:rwx -m g:${cache_group}:rwx ${cache_dir}",
+    path    => ['/usr/bin', '/bin'],
+    unless  => "getfacl -pc ${cache_dir} | grep -qx 'default:group:${cache_group}:rwx'",
+    require => [Package['acl'], File[$cache_dir]],
+  }
+
+  # Export the cache dir for interactive login shells; terraform reads this env var.
+  file { '/etc/profile.d/terraform-plugin-cache.sh':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => "# Managed by Puppet (profile::terraformer::plugin_cache)\nexport TF_PLUGIN_CACHE_DIR=${cache_dir}\n",
+  }
+}


### PR DESCRIPTION
Closes #274.

## Why

The terraformer host runs `terraform` across many working directories. By default `terraform init` downloads provider binaries into each workdir's `.terraform/providers/...`, so the real Go binaries land at per-workdir paths that vary run to run.

We want AWS Inspector EC2 scanning enabled on this host (to catch real OS-package CVEs) while suppressing **only** the noise from Terraform provider binaries. Inspector suppression filters match `file_path` with `EQUALS` / `PREFIX` / `NOT_EQUALS` only — no glob, no `CONTAINS` — so the provider binaries must sit under a single, stable prefix to be targetable.

## What

New `profile::terraformer::plugin_cache`, included from `profile::terraformer`:

- Creates `/var/cache/terraform/plugins` (Terraform won't create the cache dir itself).
- Exports `TF_PLUGIN_CACHE_DIR` via `/etc/profile.d/terraform-plugin-cache.sh` for login shells.
- Makes the cache writable by the `admin` group — `setgid` + a **default POSIX ACL** (`d:g:admin:rwx`), since terraform is run by non-privileged users in the `admin` group and setgid alone loses group-write on nested provider dirs under the default umask. Installs the `acl` package; the `setfacl` exec is idempotent via a `getfacl` guard.

Mirrored across the top-level, development, and sandbox module copies (matching the prior terraformer change in #229).

## Verified on a live terraformer

- `TF_PLUGIN_CACHE_DIR=/var/cache/terraform/plugins` in a login shell.
- `/var/cache/terraform/plugins` is `drwxrwsr-x+` group `admin`; nested provider dirs inherit setgid + the ACL.
- After `terraform init`, real provider binaries live once under `/var/cache/terraform/plugins/registry.terraform.io/...` and every `.terraform/providers/...` entry in the workdir is a symlink back into the cache.

## Companion

Pairs with infrahouse/terraform-aws-terraformer#34 (make the Inspector EC2 exclusion opt-in, then suppress the provider-binary noise via this predictable path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)