### PR TITLE
Fix ca-certificates duplicate declaration on elastic nodes

### DIFF
--- a/.claude/plans/infrahouse-keyring-convergence.md
+++ b/.claude/plans/infrahouse-keyring-convergence.md
@@ -100,9 +100,15 @@ Test node: `jumphost-sincere-crawdad.rmdbkn.ci-cd.infrahouse.com`
 
 ### Phase 2: Sandbox
 - [x] Promote: copy the change into `environments/sandbox/modules/profile` (byte-identical to dev:
-  `infrahouse_repo.pp` + `files/converge-infrahouse-keyring.sh` + `base.pp` include). PR pending.
-- [ ] Cut a release (merge → CD)
+  `infrahouse_repo.pp` + `files/converge-infrahouse-keyring.sh` + `base.pp` include).
+- [x] Cut a release — PR [#279](https://github.com/infrahouse/puppet-code/pull/279) **merged** → CD.
 - [ ] Watch sandbox nodes across roles: keyring converges, `apt-get update` clean, no drift
+  - **Regression found on `elastic_master` (sandbox `ip-10-0-2-191`):** `profile::infrahouse_repo`
+    is in `base` (every node) and `ensure_packages`'d `ca-certificates`, which collided with
+    `profile::elastic::tls`'s **native** `package { 'ca-certificates' }` → duplicate declaration,
+    catalog failed. Fix: `base`/`infrahouse_repo` now **owns** `ca-certificates` (it's a fleet-wide
+    TLS need); removed the native block from `elastic::tls`, which just `require`s it. Dev never hit
+    it (only jumphost was tested). Applied to dev + sandbox; global gets it with the Phase-3 promo.
 
 ### Phase 3: Production (global modules)
 - [ ] Promote: move the change into global `modules/profile` (production has no env-local override)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build313) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sat, 04 Jul 2026 02:14:39 +0000
+
 puppet-code (0.1.0-1build312) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/manifests/elastic/tls.pp
+++ b/environments/development/modules/profile/manifests/elastic/tls.pp
@@ -93,10 +93,9 @@ class profile::elastic::tls (
     mode    => '0600',
     require => Exec[generate_node_pem],
   }
-# Let's encrypt root certificates
-  package {'ca-certificates':
-    ensure => present,
-  }
+  # Let's encrypt root certificates. The ca-certificates package (which provides
+  # the Mozilla/ISRG roots linked below) is installed fleet-wide by profile::base
+  # -> profile::infrahouse_repo; the file resources below just require it.
   file { '/etc/elasticsearch/tls/ISRG_Root_X1.crt':
     ensure  => present,
     owner   => 'elasticsearch',

--- a/environments/sandbox/modules/profile/manifests/elastic/tls.pp
+++ b/environments/sandbox/modules/profile/manifests/elastic/tls.pp
@@ -93,10 +93,9 @@ class profile::elastic::tls (
     mode    => '0600',
     require => Exec[generate_node_pem],
   }
-# Let's encrypt root certificates
-  package {'ca-certificates':
-    ensure => present,
-  }
+  # Let's encrypt root certificates. The ca-certificates package (which provides
+  # the Mozilla/ISRG roots linked below) is installed fleet-wide by profile::base
+  # -> profile::infrahouse_repo; the file resources below just require it.
   file { '/etc/elasticsearch/tls/ISRG_Root_X1.crt':
     ensure  => present,
     owner   => 'elasticsearch',


### PR DESCRIPTION
## Regression

`profile::infrahouse_repo` (added in #278/#279, included from `profile::base` → **every node**) `ensure_packages`'d `ca-certificates`. On `elastic_master`/`elastic_data`, `profile::elastic::tls` also declared `Package['ca-certificates']` **natively**, so the catalog failed:

```
Duplicate declaration: Package[ca-certificates] is already declared at
infrahouse_repo.pp:25; cannot redeclare at elastic/tls.pp:97
```

Seen on sandbox `elastic_master` `ip-10-0-2-191`. Development never surfaced it because only the jumphost role was exercised there.

## Fix

`ca-certificates` is a fleet-wide TLS dependency, so let `base` own it:
- **Keep** it in `profile::infrahouse_repo`'s `ensure_packages` (single owner).
- **Drop** the native `package { 'ca-certificates' }` block from `profile::elastic::tls`; its file resources keep `require => Package['ca-certificates']`, which now resolves to the base-level declaration (stage-ordered *before* the elastic files — strictly better ordering).

Behavior-preserving — both were `ensure => present`. `curl`/`gnupg` don't collide (no native declarations; `elastic::repo` uses `gnupg2`, a different title).

Applied to **dev + sandbox**; global picks it up with the Phase 3 promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)