### PR TITLE
Do not let unattended-upgrades install kernels it cannot load

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet-code (0.1.0-1build323) noble; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- root <packager@infrahouse.com>  Sat, 01 Aug 2026 03:14:07 +0000
+
 puppet-code (0.1.0-1build322) noble; urgency=medium
 
   * commit event. see changes history in git log

--- a/environments/development/modules/profile/templates/unattended_upgrades/52unattended-upgrades-infrahouse.erb
+++ b/environments/development/modules/profile/templates/unattended_upgrades/52unattended-upgrades-infrahouse.erb
@@ -1,7 +1,36 @@
 // Managed by Puppet (profile::unattended_upgrades). Do not edit.
 // Augments the distro default /etc/apt/apt.conf.d/50unattended-upgrades: the
-// -security origin stays enabled there; here we only pin reboot behaviour.
-// Per-host package blacklisting is done by the relevant profile via its own
-// apt.conf.d drop-in (entries append to Unattended-Upgrade::Package-Blacklist).
+// -security origin stays enabled there; here we pin reboot behaviour and skip
+// kernels when they cannot be loaded. Further per-host blacklisting is done by
+// the relevant profile via its own apt.conf.d drop-in (entries append to
+// Unattended-Upgrade::Package-Blacklist).
 
 Unattended-Upgrade::Automatic-Reboot "<%= @automatic_reboot %>";
+<% unless @automatic_reboot -%>
+
+// Automatic-Reboot is off, so a newly installed kernel can never be loaded: it
+// sits installed-but-not-running until something reboots the host, and on
+// warm-pool GitHub runners nothing ever does -- a hibernation resume is not a
+// boot. Installing it anyway costs bootstrap time against the ASG lifecycle
+// hook budget, leaves the host on the old kernel regardless (livepatch covers
+// the running one), and makes needrestart raise a debconf "Pending kernel
+// upgrade" note with no tty to render on during provisioning, which surfaces in
+// cloud-init-output.log as an alarming-looking whiptail failure.
+//
+// Observed 2026-08-01 on a sandbox runner: Exec[gha-boot-security-upgrade]
+// pulled linux-aws 6.17.0-1019 -> 7.0.0-1009, spent ~54s doing it, and the host
+// then ran 6.17.0-1019 for the rest of its life anyway.
+//
+// Kernels reach these hosts through AMI rebuilds plus ASG cycling instead.
+//
+// Deliberately gated on Automatic-Reboot rather than hardcoded: turn that on
+// for a role and kernels become upgradable again, because then something will
+// actually load them.
+Unattended-Upgrade::Package-Blacklist {
+    "linux-aws";
+    "linux-image-";
+    "linux-headers-";
+    "linux-modules-";
+    "linux-tools-";
+};
+<% end -%>


### PR DESCRIPTION
Stops `unattended-upgrades` installing kernels on hosts that can never load them. `environments/development` only; sandbox and `modules/` follow after testing.

## Why

`Automatic-Reboot` is `false` everywhere — nothing in Hiera overrides the class default — so a kernel installed by unattended-upgrades sits installed-but-not-running until something reboots the host. On warm-pool runners nothing ever does: a hibernation resume is not a boot, which is the same premise `profile::github_runner`'s boot upgrade is already built on.

Observed 2026-08-01 on sandbox runner `ip-10-1-1-96` (`ami-0ad90a31b549bce10`):

```
/var/log/unattended-upgrades/unattended-upgrades.log
01:38:11  Starting unattended upgrades script
01:38:18  Packages that will be upgraded: linux-aws linux-headers-aws linux-image-aws
01:39:05  All upgrades installed
```

`Exec[gha-boot-security-upgrade]` pulled 6.17.0-1019 → 7.0.0-1009, spent ~54s of the 1200s lifecycle-hook budget, and the host then ran 6.17.0-1019 for the rest of its life. `canonical-livepatch` was covering the running kernel, which is the actual protection:

```
kernel: 6.17.0-1019.19~24.04.1-aws
running: true
livepatch: checkState: checked
```

It also produced this in `cloud-init-output.log`, which looks like a fault but isn't:

```
┌──── Pending kernel upgrade ────┐
│ The currently running kernel version is 6.17.0-1019-aws which is not the
│ expected kernel version 7.0.0-1009-aws.
Failed to open terminal.debconf: whiptail output the above errors, giving up!
Use of uninitialized value $ret in scalar chomp at .../ConfModule.pm line 133
```

That's needrestart's kernel hint hitting debconf with no tty during provisioning. Blacklisting the kernel removes it at the source — with running == newest-installed, needrestart has nothing to hint about, so no separate `kernelhints` override is needed.

## Verification

Patterns checked against the real package names from that host's `dpkg.log`:

```
re.match:   kernel blocked 8/8   collateral 0/6
re.search:  kernel blocked 8/8   collateral 0/6
```

Identical under both, so the behaviour does not depend on which one unattended-upgrades uses internally. `linux-libc-dev` and `util-linux` stay upgradable — they are userspace and do get real security fixes.

Both template branches render correctly (`automatic_reboot` true and false).

## Design note

Gated on `Automatic-Reboot` rather than hardcoded: turn that on for a role and kernels become upgradable again, because then something will actually load them. Kernels otherwise reach these hosts through AMI rebuilds plus ASG cycling, which is the documented strategy.

Refs #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
